### PR TITLE
feat: redesign GitHub Pages — dual-mode rendering + dev preview

### DIFF
--- a/.github/workflows/preview-pr.yml
+++ b/.github/workflows/preview-pr.yml
@@ -1,0 +1,82 @@
+name: Preview PR — Surge
+
+on:
+  pull_request:
+    paths:
+      - 'gh-pages/**'
+      - 'scripts/publish-gh-pages.sh'
+      - 'scripts/preview-dev.sh'
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch live data and build page
+        run: |
+          set -euo pipefail
+          TEMPLATE="gh-pages/index.template.html"
+          BUILD_DIR=$(mktemp -d)
+
+          echo "── Fetching data from live GitHub Pages ──"
+          curl -sf "https://yoyonel.github.io/rpi-internet-monitoring/" -o "$BUILD_DIR/live.html"
+
+          python3 << 'PYEOF'
+          import re, json, os
+
+          build = os.environ.get("BUILD_DIR", "/tmp")
+          with open(f"{build}/live.html") as f:
+              html = f.read()
+
+          m = re.search(r'(?:var|const)\s+RAW_DATA\s*=\s*({.*?});', html, re.DOTALL)
+          with open(f"{build}/data.json", "w") as f:
+              f.write(m.group(1))
+
+          m2 = re.search(r'(?:var|const)\s+ALERTS\s*=\s*(\[.*?\]);', html, re.DOTALL)
+          with open(f"{build}/alerts.json", "w") as f:
+              f.write(m2.group(1))
+
+          pts = len(json.loads(m.group(1)).get('results', [{}])[0].get('series', [{}])[0].get('values', []))
+          print(f"  → {pts} data points extracted")
+          PYEOF
+
+          echo "── Building page from template ──"
+          python3 << PYEOF
+          from datetime import datetime
+          import os
+
+          build = os.environ.get("BUILD_DIR", "/tmp")
+          with open("$TEMPLATE") as f:
+              html = f.read()
+          with open(f"{build}/data.json") as f:
+              data = f.read()
+          with open(f"{build}/alerts.json") as f:
+              alerts = f.read()
+
+          now = datetime.now().strftime('%d/%m/%Y %H:%M')
+          gen = datetime.now().strftime('%d/%m/%Y à %H:%M:%S')
+
+          html = html.replace('"__SPEEDTEST_DATA__"', data)
+          html = html.replace('"__ALERTS_DATA__"', alerts)
+          html = html.replace('__LAST_UPDATE__', now)
+          html = html.replace('__GENERATED_AT__', gen + ' (PR preview)')
+
+          with open(f"{build}/index.html", "w") as f:
+              f.write(html)
+          print(f"  → index.html ({len(html):,} bytes)")
+          PYEOF
+
+          mkdir -p _surge_deploy
+          cp "$BUILD_DIR/index.html" _surge_deploy/
+        env:
+          BUILD_DIR: /tmp/surge-build
+
+      - name: Deploy to Surge
+        uses: afc163/surge-preview@v1
+        with:
+          surge_token: ${{ secrets.SURGE_TOKEN }}
+          dist: _surge_deploy
+          build: echo "already built"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/preview-pr.yml
+++ b/.github/workflows/preview-pr.yml
@@ -7,9 +7,13 @@ on:
       - 'scripts/publish-gh-pages.sh'
       - 'scripts/preview-dev.sh'
 
+permissions:
+  pull-requests: write
+
 jobs:
   preview:
     runs-on: ubuntu-latest
+    if: ${{ secrets.SURGE_TOKEN != '' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -17,24 +21,24 @@ jobs:
         run: |
           set -euo pipefail
           TEMPLATE="gh-pages/index.template.html"
-          BUILD_DIR=$(mktemp -d)
+          BUILD_DIR="/tmp/surge-build"
+          mkdir -p "$BUILD_DIR"
 
           echo "── Fetching data from live GitHub Pages ──"
           curl -sf "https://yoyonel.github.io/rpi-internet-monitoring/" -o "$BUILD_DIR/live.html"
 
           python3 << 'PYEOF'
-          import re, json, os
+          import re, json
 
-          build = os.environ.get("BUILD_DIR", "/tmp")
-          with open(f"{build}/live.html") as f:
+          with open("/tmp/surge-build/live.html") as f:
               html = f.read()
 
           m = re.search(r'(?:var|const)\s+RAW_DATA\s*=\s*({.*?});', html, re.DOTALL)
-          with open(f"{build}/data.json", "w") as f:
+          with open("/tmp/surge-build/data.json", "w") as f:
               f.write(m.group(1))
 
           m2 = re.search(r'(?:var|const)\s+ALERTS\s*=\s*(\[.*?\]);', html, re.DOTALL)
-          with open(f"{build}/alerts.json", "w") as f:
+          with open("/tmp/surge-build/alerts.json", "w") as f:
               f.write(m2.group(1))
 
           pts = len(json.loads(m.group(1)).get('results', [{}])[0].get('series', [{}])[0].get('values', []))
@@ -42,16 +46,14 @@ jobs:
           PYEOF
 
           echo "── Building page from template ──"
-          python3 << PYEOF
+          python3 << 'PYEOF'
           from datetime import datetime
-          import os
 
-          build = os.environ.get("BUILD_DIR", "/tmp")
-          with open("$TEMPLATE") as f:
+          with open("gh-pages/index.template.html") as f:
               html = f.read()
-          with open(f"{build}/data.json") as f:
+          with open("/tmp/surge-build/data.json") as f:
               data = f.read()
-          with open(f"{build}/alerts.json") as f:
+          with open("/tmp/surge-build/alerts.json") as f:
               alerts = f.read()
 
           now = datetime.now().strftime('%d/%m/%Y %H:%M')
@@ -62,21 +64,18 @@ jobs:
           html = html.replace('__LAST_UPDATE__', now)
           html = html.replace('__GENERATED_AT__', gen + ' (PR preview)')
 
-          with open(f"{build}/index.html", "w") as f:
+          with open("/tmp/surge-build/index.html", "w") as f:
               f.write(html)
           print(f"  → index.html ({len(html):,} bytes)")
           PYEOF
 
           mkdir -p _surge_deploy
           cp "$BUILD_DIR/index.html" _surge_deploy/
-        env:
-          BUILD_DIR: /tmp/surge-build
 
       - name: Deploy to Surge
         uses: afc163/surge-preview@v1
         with:
           surge_token: ${{ secrets.SURGE_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           dist: _surge_deploy
           build: echo "already built"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/preview-pr.yml
+++ b/.github/workflows/preview-pr.yml
@@ -13,11 +13,19 @@ permissions:
 jobs:
   preview:
     runs-on: ubuntu-latest
-    if: ${{ secrets.SURGE_TOKEN != '' }}
     steps:
       - uses: actions/checkout@v4
 
+      - name: Check Surge token
+        id: check
+        run: |
+          if [ -z "${{ secrets.SURGE_TOKEN }}" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "⚠️ SURGE_TOKEN not set — skipping preview deploy"
+          fi
+
       - name: Fetch live data and build page
+        if: steps.check.outputs.skip != 'true'
         run: |
           set -euo pipefail
           TEMPLATE="gh-pages/index.template.html"
@@ -73,6 +81,7 @@ jobs:
           cp "$BUILD_DIR/index.html" _surge_deploy/
 
       - name: Deploy to Surge
+        if: steps.check.outputs.skip != 'true'
         uses: afc163/surge-preview@v1
         with:
           surge_token: ${{ secrets.SURGE_TOKEN }}

--- a/.github/workflows/preview-pr.yml
+++ b/.github/workflows/preview-pr.yml
@@ -13,19 +13,11 @@ permissions:
 jobs:
   preview:
     runs-on: ubuntu-latest
+    if: ${{ secrets.SURGE_TOKEN != '' }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check Surge token
-        id: check
-        run: |
-          if [ -z "${{ secrets.SURGE_TOKEN }}" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "⚠️ SURGE_TOKEN not set — skipping preview deploy"
-          fi
-
       - name: Fetch live data and build page
-        if: steps.check.outputs.skip != 'true'
         run: |
           set -euo pipefail
           TEMPLATE="gh-pages/index.template.html"
@@ -81,7 +73,6 @@ jobs:
           cp "$BUILD_DIR/index.html" _surge_deploy/
 
       - name: Deploy to Surge
-        if: steps.check.outputs.skip != 'true'
         uses: afc163/surge-preview@v1
         with:
           surge_token: ${{ secrets.SURGE_TOKEN }}

--- a/.github/workflows/preview-pr.yml
+++ b/.github/workflows/preview-pr.yml
@@ -13,7 +13,6 @@ permissions:
 jobs:
   preview:
     runs-on: ubuntu-latest
-    if: ${{ secrets.SURGE_TOKEN != '' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/Justfile
+++ b/Justfile
@@ -198,6 +198,51 @@ preview days="30":
 preview-dev port="8080":
     bash scripts/preview-dev.sh {{ port }}
 
+# ── Systemd Timers (replaces crontab) ──────────────────
+
+# Install systemd user timers for speedtest + GH Pages publish
+install-timers:
+    #!/usr/bin/env bash
+    set -eo pipefail
+    dir="$HOME/.config/systemd/user"
+    mkdir -p "$dir"
+    for unit in speedtest.service speedtest.timer publish-gh-pages.service publish-gh-pages.timer; do
+        cp "{{ project_dir }}/systemd/$unit" "$dir/$unit"
+        echo "  → $dir/$unit"
+    done
+    # Patch WorkingDirectory to actual project path
+    sed -i "s|WorkingDirectory=.*|WorkingDirectory={{ project_dir }}|" "$dir/speedtest.service" "$dir/publish-gh-pages.service"
+    systemctl --user daemon-reload
+    systemctl --user enable --now speedtest.timer publish-gh-pages.timer
+    echo ""
+    echo "✅ Timers installed and started:"
+    systemctl --user list-timers speedtest.timer publish-gh-pages.timer --no-pager
+
+# Uninstall systemd user timers
+uninstall-timers:
+    #!/usr/bin/env bash
+    set -eo pipefail
+    systemctl --user disable --now speedtest.timer publish-gh-pages.timer 2>/dev/null || true
+    dir="$HOME/.config/systemd/user"
+    for unit in speedtest.service speedtest.timer publish-gh-pages.service publish-gh-pages.timer; do
+        rm -f "$dir/$unit"
+    done
+    systemctl --user daemon-reload
+    echo "✅ Timers uninstalled"
+
+# Show systemd timer status and recent logs
+timer-status:
+    #!/usr/bin/env bash
+    set -eo pipefail
+    echo "── Timers ──"
+    systemctl --user list-timers speedtest.timer publish-gh-pages.timer --no-pager 2>/dev/null || echo "  (no timers installed)"
+    echo ""
+    echo "── Recent speedtest runs ──"
+    journalctl --user -u speedtest.service --no-pager -n 5 2>/dev/null || echo "  (no logs)"
+    echo ""
+    echo "── Recent publish runs ──"
+    journalctl --user -u publish-gh-pages.service --no-pager -n 5 2>/dev/null || echo "  (no logs)"
+
 # Open an InfluxDB CLI shell
 influx-shell:
     docker exec -it influxdb influx

--- a/Justfile
+++ b/Justfile
@@ -194,6 +194,10 @@ publish days="30":
 preview days="30":
     bash scripts/publish-gh-pages.sh --preview {{ days }}
 
+# Preview monitoring page using live GitHub Pages data (no RPi needed)
+preview-dev port="8080":
+    bash scripts/preview-dev.sh {{ port }}
+
 # Open an InfluxDB CLI shell
 influx-shell:
     docker exec -it influxdb influx

--- a/README.md
+++ b/README.md
@@ -111,12 +111,13 @@ crontab -e
 | `just test` | Suite de régression complète (17 checks) |
 | `just check` | Health check rapide des 4 services |
 
-### Publication
+### Publication & Preview
 
 | Commande | Description |
 |---|---|
 | `just publish [N]` | Publier la page de monitoring sur GitHub Pages (N jours d'historique, défaut: 30) |
-| `just preview [N]` | Prévisualiser en local sur `http://localhost:8080` avant publication |
+| `just preview [N]` | Prévisualiser avec données InfluxDB locales sur `http://localhost:8080` |
+| `just preview-dev [port]` | Prévisualiser avec données live GitHub Pages (sans RPi, défaut: 8080) |
 
 ### Utilitaires
 
@@ -185,21 +186,45 @@ Page statique publique avec les résultats speedtest des 30 derniers jours :
 
 **https://yoyonel.github.io/rpi-internet-monitoring/**
 
-- **Bandwidth** : graphique combiné download (bleu) + upload (violet) avec fill gradient
-- **Ping** : graphique dédié (orange/jaune)
-- **Stats** : 3 panneaux Ping / Download / Upload avec moy, min, max
-- **Time range picker** : presets 6h/12h/24h/2j/7j/30j, navigation « », zoom +/-, raccourcis clavier
-- Downsampling LTTB (800 points max) pour des performances fluides
-- Thème sombre Grafana-like, responsive (mobile-friendly)
-- Auto-refresh toutes les 11 min
+### Design & rendu
+
+- **Thème sombre** inspiré de [tsbench](https://mibayy.github.io/tsbench/) : CSS variables, police Geist + Geist Mono (Google Fonts), `backdrop-filter` nav, panels `border-radius:8px`
+- **Stats détaillées** : chaque carte affiche la **médiane** comme valeur principale + sous-métriques (min / avg / max / last pour bandwidth, min / med / p95 / max pour ping), nombre de points et plage temporelle active
+- **Alertes RPi** : état des 6 alertes Grafana avec badges ok/firing/pending, températures converties en °C
+
+### Rendu dual-mode adaptatif
+
+| Fenêtre | Mode | Détail |
+|---|---|---|
+| ≤ 48h (6h, 12h, 24h, 2j) | **Line chart** | Courbes LTTB (600 pts max) avec gradient fill |
+| > 48h (7j, 30j) | **Band chart IQR** | Bandes Q1↔Q3 + ligne médiane + whiskers min/max par bucket temporel (2h pour 7j, 6h pour 30j) |
+
+Le mode band chart est inspiré des boxplots : au lieu de tracer des milliers de points illisibles, les données sont agrégées en buckets temporels et chaque bucket affiche sa distribution statistique. Résultat : rendu instantané même sur 30 jours, et visualisation immédiate de la dispersion et des anomalies.
+
+### Stack technique (pages)
+
+| Technologie | Usage |
+|---|---|
+| [Chart.js 4](https://www.chartjs.org/) + [chartjs-adapter-date-fns](https://github.com/chartjs/chartjs-adapter-date-fns) | Graphiques temps-réel |
+| [LTTB](https://skemman.is/bitstream/1946/15343/3/SS_MSthesis.pdf) | Downsampling préservant les pics |
+| Float64Array | Stockage mémoire compact, itération cache-friendly |
+| requestAnimationFrame | Debounce du rendering |
+| Geist / Geist Mono | Typographie (Google Fonts) |
+
+### Commandes
 
 ```bash
-just preview       # Prévisualiser en local (http://localhost:8080)
-just publish       # Publication sur GitHub Pages (30 jours)
-just publish 7     # 7 jours d'historique seulement
+just preview         # Prévisualiser avec données InfluxDB locales (http://localhost:8080)
+just preview-dev     # Prévisualiser avec données live GitHub Pages (pas besoin du RPi)
+just publish         # Publication sur GitHub Pages (30 jours)
+just publish 7       # 7 jours d'historique seulement
 ```
 
-Pour automatiser via cron :
+### Développement
+
+`just preview-dev` permet de travailler sur le template sans accès au RPi : il récupère les données de la page live, les injecte dans le template local, et sert le résultat sur `http://localhost:8080`.
+
+Pour automatiser la publication via cron :
 ```bash
 crontab -e
 # Ajouter : */10 * * * * cd /path/to/project && just publish >/dev/null 2>&1

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Stack Docker pour monitorer le débit internet (download, upload, ping) via [Ook
 ## Architecture
 
 ```
-┌──────────┐  cron */10  ┌───────────┐   write    ┌──────────┐
-│  crontab │────────────▶│ speedtest │───────────▶│ InfluxDB │
-└──────────┘             └───────────┘            │  1.8.10  │
-                                                  └────┬─────┘
+┌────────────┐  */10 min  ┌───────────┐   write    ┌──────────┐
+│  systemd   │───────────▶│ speedtest │───────────▶│ InfluxDB │
+│  timer     │            └───────────┘            │  1.8.10  │
+└────────────┘                                     └────┬─────┘
 ┌──────────┐   collect   ┌───────────┐   write         │
 │  System  │────────────▶│ Telegraf  │─────────────────▶│
 │  metrics │             │  1.38.2   │                  │
@@ -23,11 +23,11 @@ Stack Docker pour monitorer le débit internet (download, upload, ping) via [Ook
                          │   1.9.4    │
                          └────────────┘
 
-┌──────────┐  cron */10  ┌──────────────┐  push   ┌──────────────┐
-│  crontab │────────────▶│ publish      │────────▶│ GitHub Pages │
-└──────────┘             │ (InfluxDB →  │         │ (static HTML │
-                         │  Chart.js)   │         │  + Chart.js) │
-                         └──────────────┘         └──────────────┘
+┌────────────┐  */10 min  ┌──────────────┐  push   ┌──────────────┐
+│  systemd   │───────────▶│ publish      │────────▶│ GitHub Pages │
+│  timer     │            │ (InfluxDB →  │         │ (static HTML │
+└────────────┘            │  Chart.js)   │         │  + Chart.js) │
+                          └──────────────┘         └──────────────┘
 ```
 
 ## Services
@@ -54,9 +54,8 @@ docker compose up -d
 docker compose build speedtest
 docker compose run --rm speedtest
 
-# 4. Configurer le cron (toutes les 10 min)
-crontab -e
-# Ajouter: */10 * * * * cd /path/to/project && /usr/bin/docker compose run --rm speedtest >/dev/null 2>&1
+# 4. Installer les timers systemd (remplace crontab)
+just install-timers
 ```
 
 ## Maintenance (`just`)
@@ -119,6 +118,16 @@ crontab -e
 | `just preview [N]` | Prévisualiser avec données InfluxDB locales sur `http://localhost:8080` |
 | `just preview-dev [port]` | Prévisualiser avec données live GitHub Pages (sans RPi, défaut: 8080) |
 
+### Scheduling (systemd timers)
+
+| Commande | Description |
+|---|---|
+| `just install-timers` | Installer les timers systemd user (speedtest + publish) |
+| `just uninstall-timers` | Désinstaller les timers |
+| `just timer-status` | État des timers + logs récents |
+
+Les timers remplacent le crontab : la configuration est versionnée dans `systemd/`, installée via `just install-timers`, et visible via `systemctl --user list-timers`. Logs consultables avec `journalctl --user -u speedtest` / `-u publish-gh-pages`.
+
 ### Utilitaires
 
 | Commande | Description |
@@ -126,7 +135,6 @@ crontab -e
 | `just alerts` | État des alertes (✅/🔴) |
 | `just influx-shell` | Shell InfluxDB interactif |
 | `just shell <svc>` | Shell bash dans un container |
-| `just cron` | Afficher le crontab actif |
 
 ## Configuration
 
@@ -224,11 +232,7 @@ just publish 7       # 7 jours d'historique seulement
 
 `just preview-dev` permet de travailler sur le template sans accès au RPi : il récupère les données de la page live, les injecte dans le template local, et sert le résultat sur `http://localhost:8080`.
 
-Pour automatiser la publication via cron :
-```bash
-crontab -e
-# Ajouter : */10 * * * * cd /path/to/project && just publish >/dev/null 2>&1
-```
+La publication est automatisée via les timers systemd (`just install-timers`). Les timers relancent speedtest et publish toutes les 10 minutes avec un délai aléatoire pour éviter la contention.
 
 ## Références
 

--- a/docs/scheduling-systemd-timers.md
+++ b/docs/scheduling-systemd-timers.md
@@ -1,0 +1,561 @@
+# Scheduling : de crontab à systemd timers
+
+> **Statut** : implémenté (unit files + Justfile), **pas encore déployé sur le RPi**.
+> À reprendre dès que l'accès au Raspberry Pi est rétabli.
+
+---
+
+## Table des matières
+
+1. [Contexte & historique](#contexte--historique)
+2. [Pourquoi quitter cron](#pourquoi-quitter-cron)
+3. [Pourquoi systemd timers](#pourquoi-systemd-timers)
+4. [Architecture](#architecture)
+5. [Référence des unit files](#référence-des-unit-files)
+   - [speedtest.service](#speedtestservice)
+   - [speedtest.timer](#speedtesttimer)
+   - [publish-gh-pages.service](#publish-gh-pagesservice)
+   - [publish-gh-pages.timer](#publish-gh-pagestimer)
+6. [Recettes Justfile](#recettes-justfile)
+7. [Checklist de migration RPi](#checklist-de-migration-rpi)
+8. [Commandes de diagnostic](#commandes-de-diagnostic)
+9. [Troubleshooting](#troubleshooting)
+10. [Décisions & alternatives envisagées](#décisions--alternatives-envisagées)
+
+---
+
+## Contexte & historique
+
+### Situation initiale (2022)
+
+Le projet a été mis en place en novembre 2022 sur un Raspberry Pi 4 sous Debian 11 (bullseye).
+La planification reposait entièrement sur **crontab user** :
+
+```
+# crontab -l (sur le RPi, utilisateur latty)
+*/10 * * * * /usr/bin/docker run --rm --network speedtest docker.local/speedtest:buster-slim
+*/10 * * * * cd /home/latty/rpi-internet-monitoring && just publish >/dev/null 2>&1
+```
+
+Deux tâches, toutes les 10 minutes :
+1. **Speedtest** : lance un conteneur Docker qui exécute le test Ookla et écrit dans InfluxDB
+2. **Publish GH Pages** : exporte les données InfluxDB, génère une page HTML statique, et push vers GitHub Pages
+
+### Évolution (avril 2026)
+
+La stack Docker a évolué (Grafana 12.4.3, Telegraf 1.38.2, image speedtest bookworm, etc.) mais
+le scheduling est resté sur crontab. Le RPi n'étant pas accessible pendant le travail de redesign,
+la décision a été prise de préparer la migration vers **systemd user timers** en amont, avec des
+fichiers versionnés dans le repo et une installation automatisée via Justfile.
+
+---
+
+## Pourquoi quitter cron
+
+| Problème | Détail |
+|---|---|
+| **Pas versionné** | Le crontab vit en dehors du repo. Aucune trace dans git, aucun review possible. Si le RPi est réinstallé, il faut se souvenir des entrées exactes. |
+| **Pas de logs structurés** | cron écrit dans syslog (`/var/log/syslog`) sans séparation par job. Filtrer les erreurs d'un job spécifique demande du `grep` manuel. La redirection `>/dev/null 2>&1` masque les erreurs silencieusement. |
+| **Pas de gestion des overlaps** | Si un speedtest prend plus de 10 minutes (réseau lent, API timeout), cron lance quand même le suivant. Deux conteneurs speedtest en parallèle peuvent produire des données corrompues ou des conflits réseau. |
+| **Pas de rattrapage** | Si le RPi est éteint ou reboot pendant un slot cron, l'exécution est simplement perdue. Aucun mécanisme de catch-up. |
+| **Pas de random delay** | Toutes les 10 min exactement. Si d'autres tâches sont calées sur le même slot, elles se disputent les ressources en même temps. |
+| **Pas de timeout** | Si `docker compose run` hang (daemon Docker bloqué, réseau down), le process reste orphelin indéfiniment. |
+| **Environnement minimal** | cron exécute dans un environnement PATH minimal. Les commandes comme `just` ou `docker compose` (v2) ne sont pas toujours dans le PATH de cron, ce qui force des chemins absolus et des hacks `source ~/.profile`. |
+
+---
+
+## Pourquoi systemd timers
+
+| Avantage | Détail |
+|---|---|
+| **Infra as code** | Les unit files vivent dans `systemd/` dans le repo. Versionnés, reviewables, reproductibles. |
+| **Logs natifs** | `journalctl --user -u speedtest` donne les logs filtrés par service, avec timestamps, exit codes, durée d'exécution. |
+| **Anti-overlap** | `Type=oneshot` + `ExecCondition` : le timer ne lance pas une nouvelle instance si la précédente tourne encore. |
+| **Persistent** | `Persistent=true` : si le RPi était éteint au moment du slot, systemd rattrape l'exécution dès le redémarrage. |
+| **RandomizedDelay** | Étale les exécutions pour éviter les pics de charge simultanés. |
+| **Timeout** | `TimeoutStartSec` tue le process s'il dépasse la durée autorisée. |
+| **User-level** | `systemctl --user` : pas besoin de root, pas de sudoers, pas de fichiers dans `/etc/systemd/`. |
+| **Intégration systemd** | `systemctl status`, `systemctl is-active`, dépendances, ordonnancement — tout l'écosystème systemd est disponible. |
+| **Installation automatisée** | `just install-timers` copie les fichiers, adapte le `WorkingDirectory`, reload, enable et start en une commande. |
+
+---
+
+## Architecture
+
+```
+Repo (versionné)                       RPi (~/.config/systemd/user/)
+─────────────────                       ─────────────────────────────
+
+systemd/
+├── speedtest.service          ──cp──▶  speedtest.service
+├── speedtest.timer            ──cp──▶  speedtest.timer
+├── publish-gh-pages.service   ──cp──▶  publish-gh-pages.service
+└── publish-gh-pages.timer     ──cp──▶  publish-gh-pages.timer
+
+Justfile
+├── install-timers       → copie + sed WorkingDirectory + daemon-reload + enable --now
+├── uninstall-timers     → disable --now + rm + daemon-reload
+└── timer-status         → list-timers + journalctl
+```
+
+### Flux d'exécution
+
+```
+systemd timer manager
+    │
+    ├── speedtest.timer (OnCalendar=*:0/10, RandomizedDelaySec=30)
+    │       │
+    │       └── speedtest.service (oneshot)
+    │               │
+    │               ├── ExecCondition: vérifie qu'aucun conteneur speedtest ne tourne
+    │               └── ExecStart: docker compose run --rm speedtest
+    │                       │
+    │                       └── Conteneur speedtest → Ookla CLI → InfluxDB
+    │
+    └── publish-gh-pages.timer (OnCalendar=*:0/10, RandomizedDelaySec=60)
+            │
+            └── publish-gh-pages.service (oneshot)
+                    │
+                    └── ExecStart: bash scripts/publish-gh-pages.sh 30
+                            │
+                            ├── Requête InfluxDB (30j de données)
+                            ├── Export alertes Grafana
+                            ├── Injection dans le template HTML
+                            └── git push vers gh-pages
+```
+
+---
+
+## Référence des unit files
+
+### speedtest.service
+
+**Chemin repo** : `systemd/speedtest.service`
+**Chemin installé** : `~/.config/systemd/user/speedtest.service`
+
+```ini
+[Unit]
+Description=Run internet speedtest and store result in InfluxDB
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/rpi-internet-monitoring
+ExecStart=/usr/bin/docker compose run --rm speedtest
+TimeoutStartSec=300
+ExecCondition=/bin/sh -c '! docker ps --format "{{.Names}}" | grep -q speedtest'
+```
+
+| Directive | Rôle |
+|---|---|
+| `Type=oneshot` | Le service exécute une commande et se termine. Pas de daemon. |
+| `WorkingDirectory=%h/rpi-internet-monitoring` | Valeur par défaut, **remplacée par le chemin réel** lors de `just install-timers` via `sed`. `%h` = `$HOME` de l'utilisateur. |
+| `ExecStart` | Lance le conteneur speedtest (build via Dockerfile, réseau Docker, écrit dans InfluxDB). `--rm` supprime le conteneur après exécution. |
+| `TimeoutStartSec=300` | 5 minutes max. Un speedtest normal prend 30-60s, mais sur réseau lent ça peut monter. Au-delà, systemd tue le process (SIGTERM puis SIGKILL). |
+| `ExecCondition` | **Guard anti-overlap**. Vérifie via `docker ps` qu'aucun conteneur nommé "speedtest" ne tourne. Si la condition échoue (exit ≠ 0), le service est skipped sans erreur. Protège contre : timer qui fire pendant qu'un ancien run est encore en cours, ou run manuel via `just speedtest` en parallèle. |
+
+### speedtest.timer
+
+**Chemin repo** : `systemd/speedtest.timer`
+
+```ini
+[Unit]
+Description=Speedtest every 10 minutes
+
+[Timer]
+OnCalendar=*:0/10
+RandomizedDelaySec=30
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+| Directive | Rôle |
+|---|---|
+| `OnCalendar=*:0/10` | Toutes les 10 minutes (`:00`, `:10`, `:20`, `:30`, `:40`, `:50`). Équivalent de `*/10 * * * *` en cron. |
+| `RandomizedDelaySec=30` | Ajoute un délai aléatoire entre 0 et 30 secondes à chaque déclenchement. Évite que speedtest et publish s'exécutent exactement au même moment. |
+| `Persistent=true` | Si le RPi était éteint au moment d'un slot, l'exécution est rattrapée au prochain démarrage. Critique pour un appareil qui peut être débranché/rebranché. |
+| `WantedBy=timers.target` | Le timer démarre automatiquement au boot (après `enable`). |
+
+### publish-gh-pages.service
+
+**Chemin repo** : `systemd/publish-gh-pages.service`
+
+```ini
+[Unit]
+Description=Publish monitoring page to GitHub Pages
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/rpi-internet-monitoring
+ExecStart=/usr/bin/bash scripts/publish-gh-pages.sh 30
+TimeoutStartSec=120
+Environment=HOME=%h
+```
+
+| Directive | Rôle |
+|---|---|
+| `ExecStart` | Exécute le script de publication avec 30 jours d'historique. Le script : exporte les données InfluxDB en JSON, récupère les alertes Grafana, injecte dans le template HTML, et push sur la branche `gh-pages`. |
+| `TimeoutStartSec=120` | 2 minutes max. Le script est principalement I/O (requête InfluxDB locale + git push). 2 min est large. |
+| `Environment=HOME=%h` | Explicite `$HOME` pour le script. Nécessaire car certaines commandes (git, ssh-agent) en dépendent et l'environnement systemd user est plus restreint que le shell interactif. |
+
+**Note** : pas de `ExecCondition` anti-overlap ici. Le script `publish-gh-pages.sh` est idempotent (il régénère et écrase la page à chaque fois), donc deux exécutions simultanées ne posent pas de problème fonctionnel (au pire un double git push, qui est un no-op si le contenu est identique).
+
+### publish-gh-pages.timer
+
+**Chemin repo** : `systemd/publish-gh-pages.timer`
+
+```ini
+[Unit]
+Description=Publish GitHub Pages every 10 minutes
+
+[Timer]
+OnCalendar=*:0/10
+RandomizedDelaySec=60
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+| Directive | Rôle |
+|---|---|
+| `RandomizedDelaySec=60` | Délai aléatoire plus large (0-60s) que le speedtest (0-30s). Objectif : la publication se fait *après* le speedtest dans la majorité des cas, pour inclure le résultat le plus récent. Ce n'est pas garanti (pas de dépendance explicite `After=`), mais statistiquement ça fonctionne bien. |
+
+---
+
+## Recettes Justfile
+
+### `just install-timers`
+
+Installe les 4 unit files dans `~/.config/systemd/user/`, patche le `WorkingDirectory` avec le
+chemin réel du projet (via `sed`), reload le daemon systemd, et active+démarre les deux timers.
+
+```bash
+just install-timers
+```
+
+Output attendu :
+```
+  → /home/latty/.config/systemd/user/speedtest.service
+  → /home/latty/.config/systemd/user/speedtest.timer
+  → /home/latty/.config/systemd/user/publish-gh-pages.service
+  → /home/latty/.config/systemd/user/publish-gh-pages.timer
+
+✅ Timers installed and started:
+NEXT                         LEFT     LAST PASSED UNIT                     ACTIVATES
+Thu 2026-04-16 15:30:22 CEST 8min left -   -      speedtest.timer          speedtest.service
+Thu 2026-04-16 15:30:45 CEST 8min left -   -      publish-gh-pages.timer   publish-gh-pages.service
+```
+
+**Ce que fait la recette :**
+1. `mkdir -p ~/.config/systemd/user/`
+2. Copie les 4 fichiers de `systemd/` vers `~/.config/systemd/user/`
+3. `sed -i` remplace `WorkingDirectory=...` par le chemin réel du projet (`justfile_directory()`)
+4. `systemctl --user daemon-reload`
+5. `systemctl --user enable --now speedtest.timer publish-gh-pages.timer`
+
+### `just uninstall-timers`
+
+Désactive et stoppe les timers, supprime les unit files, reload le daemon.
+
+```bash
+just uninstall-timers
+```
+
+### `just timer-status`
+
+Affiche l'état des timers et les 5 derniers logs de chaque service.
+
+```bash
+just timer-status
+```
+
+Output :
+```
+── Timers ──
+NEXT                         LEFT     LAST                         PASSED  UNIT                     ACTIVATES
+Thu 2026-04-16 15:40:12 CEST 3min     Thu 2026-04-16 15:30:22 CEST 6min   speedtest.timer          speedtest.service
+Thu 2026-04-16 15:40:45 CEST 4min     Thu 2026-04-16 15:30:45 CEST 6min   publish-gh-pages.timer   publish-gh-pages.service
+
+── Recent speedtest runs ──
+Apr 16 15:30:22 raspberrypi speedtest[12345]: {"results":[...]}
+Apr 16 15:20:08 raspberrypi speedtest[12300]: {"results":[...]}
+
+── Recent publish runs ──
+Apr 16 15:30:45 raspberrypi publish-gh-pages[12400]: → 4318 data points exported
+Apr 16 15:20:33 raspberrypi publish-gh-pages[12350]: → 4317 data points exported
+```
+
+---
+
+## Checklist de migration RPi
+
+> **À exécuter quand l'accès au Raspberry Pi est rétabli.**
+
+### Pré-requis
+
+- [ ] SSH vers le RPi fonctionnel (`ssh latty@192.168.1.24`)
+- [ ] Le repo est à jour sur le RPi (`git pull` ou `git fetch && git checkout feat/gh-pages-redesign`)
+- [ ] Docker fonctionne (`docker ps`)
+- [ ] `just` est installé (`just --version`)
+- [ ] `lingering` systemd activé pour l'utilisateur (voir ci-dessous)
+
+### Étapes
+
+```bash
+# 1. Se connecter au RPi
+ssh latty@192.168.1.24
+
+# 2. Aller dans le projet
+cd ~/rpi-internet-monitoring   # ou ~/Prog/rpi-internet-monitoring selon install
+
+# 3. Mettre à jour le code
+git fetch origin
+git checkout feat/gh-pages-redesign   # ou master si déjà mergé
+git pull
+
+# 4. Vérifier la stack Docker
+just status
+just check
+
+# 5. Activer le lingering systemd (IMPORTANT, une seule fois)
+#    Sans ça, les timers user sont stoppés quand la session SSH se ferme.
+loginctl enable-linger latty
+
+# 6. Supprimer l'ancien crontab
+crontab -l                    # noter les entrées actuelles (backup)
+crontab -e                    # supprimer les lignes speedtest et publish
+# OU
+crontab -r                    # si le crontab ne contient QUE ces deux entrées
+
+# 7. Installer les timers systemd
+just install-timers
+
+# 8. Vérifier que les timers tournent
+just timer-status
+
+# 9. Attendre 10-15 minutes, puis vérifier les logs
+just timer-status
+# Vérifier que speedtest.service et publish-gh-pages.service ont des entrées récentes
+
+# 10. Vérifier que GitHub Pages se met à jour
+# → https://yoyonel.github.io/rpi-internet-monitoring/
+```
+
+### Point critique : `loginctl enable-linger`
+
+Par défaut, systemd user services sont **stoppés quand l'utilisateur se déconnecte** (fermeture SSH).
+`enable-linger` fait persister les services même sans session active.
+
+```bash
+# Activer (une seule fois, persistant après reboot)
+loginctl enable-linger latty
+
+# Vérifier
+loginctl show-user latty | grep Linger
+# Linger=yes
+```
+
+**Sans cette commande, les timers s'arrêteront dès la déconnexion SSH.** C'est le piège classique
+des systemd user timers sur un serveur headless.
+
+### Rollback
+
+Si quelque chose ne fonctionne pas, on peut revenir au crontab en 30 secondes :
+
+```bash
+# Désinstaller les timers
+just uninstall-timers
+
+# Remettre le crontab
+crontab -e
+# */10 * * * * cd /home/latty/rpi-internet-monitoring && /usr/bin/docker compose run --rm speedtest >/dev/null 2>&1
+# */10 * * * * cd /home/latty/rpi-internet-monitoring && bash scripts/publish-gh-pages.sh 30 >/dev/null 2>&1
+```
+
+---
+
+## Commandes de diagnostic
+
+### État des timers
+
+```bash
+# Liste des timers actifs avec prochaine exécution
+systemctl --user list-timers
+
+# État détaillé d'un timer spécifique
+systemctl --user status speedtest.timer
+systemctl --user status publish-gh-pages.timer
+
+# État du service (dernière exécution, exit code, durée)
+systemctl --user status speedtest.service
+systemctl --user status publish-gh-pages.service
+```
+
+### Logs
+
+```bash
+# Logs d'un service spécifique
+journalctl --user -u speedtest.service --no-pager -n 20
+
+# Logs avec timestamps et exit codes
+journalctl --user -u speedtest.service -o verbose --no-pager -n 5
+
+# Logs depuis le dernier boot
+journalctl --user -u speedtest.service -b
+
+# Logs en temps réel (follow)
+journalctl --user -u speedtest.service -f
+
+# Tous les logs des deux services
+journalctl --user -u speedtest.service -u publish-gh-pages.service --no-pager -n 30
+
+# Logs des erreurs uniquement
+journalctl --user -u speedtest.service -p err --no-pager
+```
+
+### Exécution manuelle (debug)
+
+```bash
+# Lancer manuellement un service (sans attendre le timer)
+systemctl --user start speedtest.service
+
+# Vérifier le résultat
+systemctl --user status speedtest.service
+journalctl --user -u speedtest.service -n 1 --no-pager
+```
+
+---
+
+## Troubleshooting
+
+### Le timer ne fire pas
+
+```bash
+# Vérifier que le timer est enabled et active
+systemctl --user is-enabled speedtest.timer    # → enabled
+systemctl --user is-active speedtest.timer     # → active
+
+# Si "inactive", redémarrer
+systemctl --user start speedtest.timer
+
+# Vérifier le lingering
+loginctl show-user latty | grep Linger         # → Linger=yes
+```
+
+### Le service échoue
+
+```bash
+# Voir l'exit code et les logs
+systemctl --user status speedtest.service
+journalctl --user -u speedtest.service -n 10
+
+# Causes fréquentes :
+# - Docker daemon non démarré → sudo systemctl start docker
+# - Image speedtest pas buildée → just build
+# - Conteneur speedtest déjà en cours (ExecCondition skip) → docker ps | grep speedtest
+# - Réseau Docker manquant → docker network ls
+```
+
+### Les timers s'arrêtent après déconnexion SSH
+
+```bash
+# Le lingering n'est pas activé
+loginctl enable-linger latty
+
+# Vérifier
+loginctl show-user latty | grep Linger
+```
+
+### WorkingDirectory incorrect
+
+```bash
+# Vérifier le chemin dans le service installé
+cat ~/.config/systemd/user/speedtest.service | grep WorkingDirectory
+
+# Si incorrect, réinstaller :
+just install-timers
+# La recette re-copie et re-patche automatiquement
+```
+
+### Le publish échoue (git push)
+
+```bash
+journalctl --user -u publish-gh-pages.service -n 10
+
+# Causes fréquentes :
+# - Clé SSH non chargée → évaluer ssh-agent dans le service ou utiliser HTTPS + token
+# - Pas de droits push sur le repo → gh auth status
+# - Branche gh-pages inexistante → git ls-remote --heads origin gh-pages
+```
+
+**Note importante sur SSH** : dans un contexte systemd user sans session interactive, `ssh-agent`
+n'est pas automatiquement démarré. Si le publish utilise SSH pour git push, il faudra soit :
+- Configurer un `ssh-agent.service` systemd user
+- Utiliser une clé SSH sans passphrase (moins sécurisé mais fonctionnel)
+- Basculer le remote sur HTTPS avec un token GitHub (plus simple)
+
+---
+
+## Décisions & alternatives envisagées
+
+### Alternative 1 : rester sur cron + wrapper script
+
+**Idée** : garder cron mais écrire un script `scripts/cron-wrapper.sh` qui gère les logs, overlaps et timeouts.
+
+**Rejeté car** :
+- Réinventer la roue — systemd fait déjà tout ça nativement
+- Le crontab lui-même reste hors repo (pas versionné)
+- Pas de `Persistent` (catch-up après downtime)
+
+### Alternative 2 : cron + `flock`
+
+**Idée** : `*/10 * * * * flock -n /tmp/speedtest.lock docker compose run --rm speedtest`
+
+**Rejeté car** :
+- Résout seulement l'anti-overlap, pas les autres problèmes (logs, timeout, catch-up, versioning)
+- `flock` ne gère pas le timeout natif
+
+### Alternative 3 : Docker-native scheduling (ofelia, etc.)
+
+**Idée** : utiliser un scheduler Docker comme [ofelia](https://github.com/mcuadros/ofelia) ou le
+`deploy.restart_policy` de Docker Swarm pour planifier les tâches.
+
+**Rejeté car** :
+- Ajoute un service supplémentaire à maintenir
+- Ofelia est un projet peu actif
+- Swarm est overkill pour un RPi mono-node
+- Le publish GH Pages a besoin de git (pas idéal dans un conteneur)
+
+### Alternative 4 : GitHub Actions scheduled workflow
+
+**Idée** : un workflow `schedule:` sur GitHub qui SSH vers le RPi pour lancer les tâches.
+
+**Rejeté car** :
+- Dépendance à GitHub (si GitHub Actions est down, plus de monitoring)
+- Nécessite d'exposer le RPi en SSH sur internet (sécurité)
+- Latence et overhead inutiles
+
+### Choix final : systemd user timers
+
+**Retenu car** :
+- Zéro dépendance externe (systemd est déjà sur le RPi)
+- Toutes les fonctionnalités nécessaires par défaut (logs, overlap, timeout, persistent, random delay)
+- Fichiers versionnés dans le repo (infra as code)
+- Installation/désinstallation en une commande
+- Rollback trivial vers cron si besoin
+- Standard Linux, documentation abondante
+
+---
+
+## Fichiers du projet
+
+| Fichier | Rôle |
+|---|---|
+| `systemd/speedtest.service` | Service oneshot : lance le conteneur speedtest |
+| `systemd/speedtest.timer` | Timer : toutes les 10 min, 30s random delay |
+| `systemd/publish-gh-pages.service` | Service oneshot : publie sur GitHub Pages |
+| `systemd/publish-gh-pages.timer` | Timer : toutes les 10 min, 60s random delay |
+| `Justfile` | Recettes `install-timers` / `uninstall-timers` / `timer-status` |
+| `docs/scheduling-systemd-timers.md` | Ce document |

--- a/gh-pages/index.template.html
+++ b/gh-pages/index.template.html
@@ -1,505 +1,653 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="refresh" content="660">
-    <title>Internet Speed Monitor — RPi4</title>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3"></script>
-    <style>
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            background: #111217;
-            color: #c9d1d9;
-            padding: 20px;
-            max-width: 1200px;
-            margin: 0 auto;
-        }
-        header {
-            text-align: center;
-            margin-bottom: 16px;
-            padding: 20px;
-            background: #181b1f;
-            border-radius: 8px;
-            border: 1px solid #2a2e35;
-        }
-        h1 { font-size: 1.6em; color: #c9d1d9; margin-bottom: 4px; font-weight: 600; }
-        .subtitle { color: #6e7681; font-size: 0.9em; }
-        .updated { color: #6e7681; font-size: 0.82em; margin-top: 6px; }
-        .updated time { color: #6e9fff; font-weight: 500; }
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="refresh" content="660">
+<title>Internet Speed Monitor — RPi4</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3"></script>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{
+  --bg:#0c0c0d;--bg2:#141415;--surface:#1a1a1c;--surface2:#222224;
+  --border:#2a2a2d;--border2:#333336;
+  --text:#ededed;--text2:#888;--text3:#555;
+  --blue:#7eb6f6;--purple:#c982e0;--orange:#f2a93b;
+  --green:#22c55e;--green2:#4ade80;--red:#ef4444;--red2:#f87171;--amber:#eab308;
+}
+html{scroll-behavior:smooth}
+body{background:var(--bg);color:var(--text);font-family:'Geist',system-ui,-apple-system,sans-serif;line-height:1.6;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
+.w{max-width:960px;margin:0 auto;padding:0 20px}
 
-        /* ── Time Range Picker ── */
-        .time-picker {
-            display: flex; align-items: center; justify-content: flex-end;
-            gap: 4px; margin-bottom: 16px; flex-wrap: wrap;
-        }
-        .time-picker .nav-btn, .time-picker .zoom-btn {
-            background: #181b1f; border: 1px solid #2a2e35; color: #6e7681;
-            width: 30px; height: 30px; border-radius: 4px; cursor: pointer;
-            font-size: 13px; display: flex; align-items: center; justify-content: center;
-            transition: all 0.12s;
-        }
-        .time-picker .nav-btn:hover, .time-picker .zoom-btn:hover { background: #22262d; color: #c9d1d9; }
-        .time-picker .range-group {
-            display: flex; align-items: center; gap: 1px;
-            background: #181b1f; border: 1px solid #2a2e35; border-radius: 4px; padding: 2px;
-        }
-        .time-picker .range-btn {
-            background: transparent; border: none; color: #6e7681;
-            padding: 4px 10px; border-radius: 3px; cursor: pointer;
-            font-size: 0.82em; font-weight: 500; transition: all 0.12s; white-space: nowrap;
-        }
-        .time-picker .range-btn:hover { color: #c9d1d9; background: #22262d; }
-        .time-picker .range-btn.active { background: #3871d4; color: #fff; }
-        .time-picker .range-label {
-            color: #6e9fff; font-size: 0.8em; font-weight: 500;
-            margin-left: 8px; min-width: 180px; text-align: center;
-        }
+/* ── NAV ── */
+nav{position:sticky;top:0;z-index:50;background:rgba(12,12,13,.88);backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);border-bottom:1px solid var(--border);padding:0 20px}
+nav .inner{max-width:960px;margin:0 auto;display:flex;align-items:center;justify-content:space-between;height:48px}
+nav .brand{font-weight:700;font-size:.875rem;letter-spacing:-.02em}
+nav .brand .hi{color:var(--blue)}
+nav .meta{font-size:.72rem;color:var(--text3);font-family:'Geist Mono',monospace}
+nav .meta time{color:var(--blue)}
 
-        /* ── Stat Cards (Grafana-style) ── */
-        .stats-row {
-            display: grid; grid-template-columns: repeat(3, 1fr);
-            gap: 8px; margin-bottom: 12px;
-        }
-        .stat-panel {
-            background: #181b1f; border: 1px solid #2a2e35; border-radius: 8px;
-            padding: 16px 20px; text-align: center;
-        }
-        .stat-panel .stat-title { color: #6e7681; font-size: 0.8em; margin-bottom: 4px; }
-        .stat-panel .stat-value { font-size: 2.8em; font-weight: 300; line-height: 1.1; }
-        .stat-panel .stat-unit { font-size: 0.55em; font-weight: 400; color: #6e7681; vertical-align: baseline; margin-left: 2px; }
-        .stat-panel .stat-sub { color: #6e7681; font-size: 0.72em; margin-top: 4px; }
-        .stat-panel.ping .stat-value { color: #ff9830; }
-        .stat-panel.download .stat-value { color: #7eb6f6; }
-        .stat-panel.upload .stat-value { color: #c982e0; }
+/* ── HERO ── */
+.hero{padding:40px 0 24px;border-bottom:1px solid var(--border)}
+.hero h1{font-size:clamp(1.4rem,4vw,2rem);font-weight:800;letter-spacing:-.03em;line-height:1.1;margin-bottom:6px}
+.hero .sub{color:var(--text2);font-size:.85rem}
 
-        /* ── Chart Panels ── */
-        .chart-panel {
-            background: #181b1f; border: 1px solid #2a2e35; border-radius: 8px;
-            padding: 16px 16px 12px; margin-bottom: 12px;
-        }
-        .chart-panel .panel-header {
-            display: flex; justify-content: space-between; align-items: center;
-            margin-bottom: 8px;
-        }
-        .chart-panel h2 { font-size: 0.9em; color: #c9d1d9; font-weight: 500; }
-        .chart-legend {
-            display: flex; gap: 16px; font-size: 0.72em; color: #6e7681;
-        }
-        .chart-legend .leg-item { display: flex; align-items: center; gap: 4px; }
-        .chart-legend .leg-color {
-            width: 14px; height: 3px; border-radius: 2px; display: inline-block;
-        }
+/* ── STATS ROW ── */
+.stats{display:grid;grid-template-columns:repeat(3,1fr);border-bottom:1px solid var(--border)}
+.stat{padding:20px 16px;text-align:center;border-right:1px solid var(--border)}
+.stat:last-child{border-right:none}
+.stat .v{font-size:clamp(1.8rem,4vw,2.6rem);font-weight:800;letter-spacing:-.03em;line-height:1}
+.stat .v .u{font-size:.4em;font-weight:400;color:var(--text3);margin-left:2px}
+.stat .l{font-size:.7rem;color:var(--text3);margin-top:6px;text-transform:uppercase;letter-spacing:.06em}
+.stat.pi .v{color:var(--orange)}
+.stat.dl .v{color:var(--blue)}
+.stat.ul .v{color:var(--purple)}
+/* stat detail grid */
+.stat .sg{display:grid;grid-template-columns:repeat(2,1fr);gap:2px 12px;margin-top:8px;text-align:left}
+.stat .sg dt{font-size:.6rem;color:var(--text3);text-transform:uppercase;letter-spacing:.05em;font-family:'Geist Mono',monospace}
+.stat .sg dd{font-size:.78rem;font-weight:600;color:var(--text2);margin:0 0 2px;font-family:'Geist Mono',monospace}
+.stat .pts{font-size:.6rem;color:var(--text3);margin-top:6px;font-family:'Geist Mono',monospace}
 
-        .no-data { text-align: center; padding: 40px; color: #484f58; font-size: 1.1em; }
+/* ── ALERTS ── */
+.alerts{padding:20px 0;border-bottom:1px solid var(--border)}
+.stitle{font-size:.7rem;color:var(--text3);text-transform:uppercase;letter-spacing:.1em;margin-bottom:10px;font-weight:500}
+.al-row{display:flex;align-items:center;gap:10px;padding:7px 0;border-bottom:1px solid var(--border);font-size:.8rem}
+.al-row:last-child{border-bottom:none}
+.al-icon{width:18px;text-align:center;flex-shrink:0;font-size:.9rem}
+.al-name{color:var(--text);font-weight:600;min-width:160px;font-size:.8rem}
+.al-sum{color:var(--text2);flex:1;font-family:'Geist Mono',monospace;font-size:.72rem}
+.al-badge{font-size:.6rem;font-weight:600;padding:2px 8px;border-radius:4px;text-transform:uppercase;letter-spacing:.04em;flex-shrink:0}
+.al-badge.ok{background:rgba(34,197,94,.08);color:var(--green2);border:1px solid rgba(34,197,94,.15)}
+.al-badge.firing{background:rgba(239,68,68,.08);color:var(--red2);border:1px solid rgba(239,68,68,.15)}
+.al-badge.pending{background:rgba(234,179,8,.08);color:var(--amber);border:1px solid rgba(234,179,8,.15)}
 
-        /* ── Alerts Panel ── */
-        .alerts-panel {
-            background: #181b1f; border: 1px solid #2a2e35; border-radius: 8px;
-            padding: 14px 16px; margin-bottom: 12px;
-        }
-        .alerts-panel h2 { font-size: 0.9em; color: #c9d1d9; font-weight: 500; margin-bottom: 10px; }
-        .alert-row {
-            display: flex; align-items: center; gap: 10px;
-            padding: 6px 0; border-bottom: 1px solid #1e2228;
-            font-size: 0.82em;
-        }
-        .alert-row:last-child { border-bottom: none; }
-        .alert-icon { font-size: 1.1em; flex-shrink: 0; width: 20px; text-align: center; }
-        .alert-name { color: #c9d1d9; font-weight: 500; min-width: 180px; }
-        .alert-summary { color: #6e7681; flex: 1; }
-        .alert-badge {
-            font-size: 0.7em; font-weight: 600; padding: 2px 8px;
-            border-radius: 3px; text-transform: uppercase; flex-shrink: 0;
-        }
-        .alert-badge.normal { background: #1a3a2a; color: #3fb950; }
-        .alert-badge.firing { background: #3d1a1a; color: #f85149; }
-        .alert-badge.pending { background: #3d2e1a; color: #d29922; }
-        .alert-badge.sev-critical { border: 1px solid #f85149; }
-        .alert-badge.sev-warning { border: 1px solid #d29922; }
+/* ── TIME PICKER ── */
+.tp{display:flex;align-items:center;justify-content:flex-end;gap:4px;padding:16px 0;flex-wrap:wrap}
+.tp .nb,.tp .zb{background:var(--surface);border:1px solid var(--border);color:var(--text3);width:30px;height:30px;border-radius:4px;cursor:pointer;font-size:13px;display:flex;align-items:center;justify-content:center;transition:all .15s}
+.tp .nb:hover,.tp .zb:hover{background:var(--surface2);color:var(--text)}
+.tp .rg{display:flex;gap:1px;background:var(--surface);border:1px solid var(--border);border-radius:4px;padding:2px}
+.tp .rb{background:transparent;border:none;color:var(--text3);padding:4px 10px;border-radius:3px;cursor:pointer;font-size:.76rem;font-weight:500;transition:all .15s;font-family:'Geist Mono',monospace}
+.tp .rb:hover{color:var(--text);background:var(--surface2)}
+.tp .rb.on{background:var(--blue);color:#fff}
+.tp .rl{font-size:.72rem;color:var(--text3);font-family:'Geist Mono',monospace;margin-left:8px;min-width:180px;text-align:center}
 
-        @media (max-width: 600px) {
-            .alert-row { flex-wrap: wrap; gap: 4px; }
-            .alert-name { min-width: auto; }
-            .alert-summary { display: none; }
-        }
+/* ── CHART PANELS ── */
+.panel{background:var(--bg2);border:1px solid var(--border);border-radius:8px;padding:20px;margin-bottom:12px}
+.panel .hd{display:flex;justify-content:space-between;align-items:center;margin-bottom:12px}
+.panel .hd h2{font-size:.85rem;font-weight:600;letter-spacing:-.01em}
+.panel .lg{display:flex;gap:16px;font-size:.72rem;color:var(--text2)}
+.panel .lg span{display:flex;align-items:center;gap:5px}
+.panel .lg i{width:14px;height:3px;border-radius:2px;display:inline-block;font-style:normal}
+.no-data{text-align:center;padding:48px;color:var(--text3);font-size:.9rem}
 
-        footer {
-            text-align: center; color: #3d424a; font-size: 0.75em; margin-top: 20px; padding: 12px;
-        }
-        footer a { color: #6e9fff; text-decoration: none; }
+/* ── FOOTER ── */
+footer{border-top:1px solid var(--border);padding:24px 0;text-align:center}
+footer p{font-size:.7rem;color:var(--text3)}
+footer a{color:var(--blue);text-decoration:none}
+footer a:hover{text-decoration:underline}
 
-        @media (max-width: 600px) {
-            body { padding: 10px; }
-            .stats-row { grid-template-columns: 1fr; }
-            .stat-panel .stat-value { font-size: 2em; }
-            .time-picker .range-btn { padding: 3px 7px; font-size: 0.75em; }
-            .time-picker .range-label { min-width: 140px; font-size: 0.72em; }
-            .chart-legend { flex-wrap: wrap; gap: 8px; }
-        }
-    </style>
+/* ── RESPONSIVE ── */
+@media(max-width:640px){
+  .hero{padding:28px 0 16px}.hero h1{font-size:1.3rem}
+  .stat .v{font-size:1.6rem}.stat{padding:16px 10px}
+  .stat .sg{grid-template-columns:repeat(2,1fr);gap:1px 8px}
+  .stat .sg dd{font-size:.7rem}
+  .panel{padding:14px}
+  .al-row{flex-wrap:wrap;gap:4px}.al-name{min-width:auto}.al-sum{display:none}
+  .tp .rb{padding:3px 7px;font-size:.7rem}.tp .rl{min-width:130px;font-size:.66rem}
+  nav .meta{font-size:.65rem}
+}
+@media(max-width:380px){
+  .stats{grid-template-columns:1fr}
+  .stat{border-right:none;border-bottom:1px solid var(--border);padding:14px 10px}
+  .stat:last-child{border-bottom:none}
+  .stat .sg{grid-template-columns:repeat(4,1fr)}
+}
+</style>
 </head>
 <body>
-    <header>
-        <h1>Internet Speed Monitor</h1>
-        <p class="subtitle">Raspberry Pi 4 &mdash; Speedtest toutes les 10 min</p>
-        <p class="updated">Derni&egrave;re mise &agrave; jour : <time>__LAST_UPDATE__</time></p>
-    </header>
 
-    <div class="time-picker" id="timePicker">
-        <button class="nav-btn" id="btnBack" title="Reculer">&laquo;</button>
-        <div class="range-group">
-            <button class="range-btn" data-hours="6">6h</button>
-            <button class="range-btn" data-hours="12">12h</button>
-            <button class="range-btn" data-hours="24">24h</button>
-            <button class="range-btn active" data-hours="48">2j</button>
-            <button class="range-btn" data-hours="168">7j</button>
-            <button class="range-btn" data-hours="720">30j</button>
-        </div>
-        <button class="nav-btn" id="btnForward" title="Avancer">&raquo;</button>
-        <button class="zoom-btn" id="btnZoomOut" title="Zoom out">&#x2212;</button>
-        <button class="zoom-btn" id="btnZoomIn" title="Zoom in">+</button>
-        <span class="range-label" id="rangeLabel"></span>
-    </div>
+<nav>
+  <div class="inner">
+    <div class="brand">speed<span class="hi">monitor</span></div>
+    <div class="meta">Mise &agrave; jour : <time>__LAST_UPDATE__</time></div>
+  </div>
+</nav>
 
-    <div class="stats-row" id="statsRow"></div>
+<div class="w">
 
-    <div class="alerts-panel" id="alertsPanel" style="display:none">
-        <h2>Alertes RPi</h2>
-        <div id="alertsList"></div>
-    </div>
+<section class="hero">
+  <h1>Internet Speed Monitor</h1>
+  <p class="sub">Raspberry Pi 4 &mdash; Speedtest Ookla toutes les 10 min</p>
+</section>
 
-    <div class="chart-panel">
-        <div class="panel-header">
-            <h2>Bandwidth</h2>
-            <div class="chart-legend" id="bwLegend"></div>
-        </div>
-        <canvas id="bandwidthChart"></canvas>
-    </div>
+<div class="stats" id="statsRow"></div>
 
-    <div class="chart-panel">
-        <div class="panel-header">
-            <h2>Ping</h2>
-            <div class="chart-legend" id="pingLegend"></div>
-        </div>
-        <canvas id="pingChart"></canvas>
-    </div>
+<section class="alerts" id="alertsSec" style="display:none">
+  <div class="stitle">Alertes RPi</div>
+  <div id="alertsList"></div>
+</section>
 
-    <footer>
-        <a href="https://www.speedtest.net/apps/cli" rel="noopener">Ookla Speedtest CLI</a> sur Raspberry Pi 4 &mdash;
-        Page g&eacute;n&eacute;r&eacute;e le __GENERATED_AT__
-    </footer>
+<div class="tp">
+  <button class="nb" id="btnBack" title="Reculer">&laquo;</button>
+  <div class="rg">
+    <button class="rb" data-hours="6">6h</button>
+    <button class="rb" data-hours="12">12h</button>
+    <button class="rb" data-hours="24">24h</button>
+    <button class="rb on" data-hours="48">2j</button>
+    <button class="rb" data-hours="168">7j</button>
+    <button class="rb" data-hours="720">30j</button>
+  </div>
+  <button class="nb" id="btnFwd" title="Avancer">&raquo;</button>
+  <button class="zb" id="btnZoomOut" title="Zoom −">&minus;</button>
+  <button class="zb" id="btnZoomIn" title="Zoom +">+</button>
+  <span class="rl" id="rangeLabel"></span>
+</div>
 
-    <script>
-    var RAW_DATA = "__SPEEDTEST_DATA__";
-    var ALERTS = "__ALERTS_DATA__";
+<div class="panel">
+  <div class="hd">
+    <h2>Bandwidth</h2>
+    <div class="lg" id="bwLeg"></div>
+  </div>
+  <canvas id="bwChart"></canvas>
+</div>
 
-    // Render alerts
-    (function() {
-        if (!ALERTS || !ALERTS.length) return;
-        var panel = document.getElementById('alertsPanel');
-        var list = document.getElementById('alertsList');
-        panel.style.display = '';
+<div class="panel">
+  <div class="hd">
+    <h2>Latency</h2>
+    <div class="lg" id="piLeg"></div>
+  </div>
+  <canvas id="piChart"></canvas>
+</div>
 
-        var html = ALERTS.map(function(a) {
-            var icon = a.state === 'firing' ? '\uD83D\uDD34' : a.state === 'pending' ? '\u26A0\uFE0F' : '\u2705';
-            var badgeCls = a.state === 'firing' ? 'firing' : a.state === 'pending' ? 'pending' : 'normal';
-            var sevCls = a.severity === 'critical' ? ' sev-critical' : ' sev-warning';
-            var stateLabel = a.state === 'inactive' ? 'ok' : a.state;
-            return '<div class="alert-row">'
-                + '<span class="alert-icon">' + icon + '</span>'
-                + '<span class="alert-name">' + a.name + '</span>'
-                + '<span class="alert-summary">' + (a.summary || '') + '</span>'
-                + '<span class="alert-badge ' + badgeCls + sevCls + '">' + stateLabel + '</span>'
-                + '</div>';
-        }).join('');
-        list.innerHTML = html;
-    })();
+</div>
 
-    (function() {
-        if (!RAW_DATA || !RAW_DATA.results) {
-            document.getElementById('statsRow').innerHTML = '<div class="no-data">Aucune donn\u00e9e disponible</div>';
-            return;
+<footer><p>
+  <a href="https://www.speedtest.net/apps/cli">Ookla Speedtest CLI</a> sur Raspberry Pi 4 &mdash;
+  G&eacute;n&eacute;r&eacute; le __GENERATED_AT__
+</p></footer>
+
+<script>
+const RAW_DATA = "__SPEEDTEST_DATA__";
+const ALERTS = "__ALERTS_DATA__";
+
+// ── Alerts ───────────────────────────────────────────────────
+(() => {
+  if (!Array.isArray(ALERTS) || !ALERTS.length) return;
+  document.getElementById('alertsSec').style.display = '';
+  // Convert m°C to °C in alert summaries
+  const fixTemp = s => s ? s.replace(/(\d+)\s*m°C/g, (_, v) => (parseInt(v) / 1000).toFixed(2) + ' °C') : '';
+
+  document.getElementById('alertsList').innerHTML = ALERTS.map(a => {
+    const icon = a.state === 'firing' ? '\uD83D\uDD34' : a.state === 'pending' ? '\u26A0\uFE0F' : '\u2705';
+    const badge = a.state === 'firing' ? 'firing' : a.state === 'pending' ? 'pending' : 'ok';
+    const label = a.state === 'inactive' ? 'ok' : a.state;
+    return `<div class="al-row">
+      <span class="al-icon">${icon}</span>
+      <span class="al-name">${a.name}</span>
+      <span class="al-sum">${fixTemp(a.summary)}</span>
+      <span class="al-badge ${badge}">${label}</span>
+    </div>`;
+  }).join('');
+})();
+
+// ── Charts & Data ────────────────────────────────────────────
+(() => {
+  const statsEl = document.getElementById('statsRow');
+
+  if (!RAW_DATA?.results?.[0]?.series?.[0]?.values?.length) {
+    statsEl.innerHTML = '<div class="no-data" style="grid-column:1/-1">Aucune donn\u00e9e disponible</div>';
+    return;
+  }
+
+  const { columns: cols, values } = RAW_DATA.results[0].series[0];
+  const iT = cols.indexOf('time'), iDl = cols.indexOf('download_bandwidth');
+  const iUl = cols.indexOf('upload_bandwidth'), iPi = cols.indexOf('ping_latency');
+  const LEN = values.length;
+
+  // ── Typed arrays ───────────────────────────────────────────
+  const ts = new Float64Array(LEN);
+  const dl = new Float64Array(LEN);
+  const ul = new Float64Array(LEN);
+  const pi = new Float64Array(LEN);
+
+  for (let i = 0; i < LEN; i++) {
+    const r = values[i];
+    ts[i] = new Date(r[iT]).getTime();
+    dl[i] = r[iDl] / 125000;
+    ul[i] = r[iUl] / 125000;
+    pi[i] = r[iPi];
+  }
+
+  // ── LTTB (typed array → [{x,y}]) ──────────────────────────
+  const MAX_PTS = 600;
+  const lttb = (xArr, yArr, i0, i1, n) => {
+    const len = i1 - i0;
+    if (len <= n) {
+      const out = new Array(len);
+      for (let i = 0; i < len; i++) out[i] = { x: xArr[i0 + i], y: yArr[i0 + i] };
+      return out;
+    }
+    const out = [{ x: xArr[i0], y: yArr[i0] }];
+    const bs = (len - 2) / (n - 2);
+    let a = 0;
+    for (let i = 0; i < n - 2; i++) {
+      const s = Math.floor((i + 1) * bs) + 1;
+      const e = Math.min(Math.floor((i + 2) * bs) + 1, len);
+      const ns = Math.min(Math.floor((i + 2) * bs) + 1, len - 1);
+      const ne = Math.min(Math.floor((i + 3) * bs) + 1, len);
+      let ax = 0, ay = 0, c = 0;
+      for (let j = ns; j < ne; j++) { ax += xArr[i0 + j]; ay += yArr[i0 + j]; c++; }
+      if (c) { ax /= c; ay /= c; }
+      let ma = -1, bi = s;
+      const px = xArr[i0 + a], py = yArr[i0 + a];
+      for (let j = s; j < e; j++) {
+        const ar = Math.abs((px - ax) * (yArr[i0 + j] - py) - (px - xArr[i0 + j]) * (ay - py));
+        if (ar > ma) { ma = ar; bi = j; }
+      }
+      out.push({ x: xArr[i0 + bi], y: yArr[i0 + bi] });
+      a = bi;
+    }
+    out.push({ x: xArr[i0 + len - 1], y: yArr[i0 + len - 1] });
+    return out;
+  };
+
+  // ── Bucketize for band chart ───────────────────────────────
+  // Returns array of { x, min, q1, med, q3, max, n }
+  const bucketize = (xArr, yArr, i0, i1, bucketMs) => {
+    const buckets = [];
+    if (i0 >= i1) return buckets;
+    const buf = [];
+    let bStart = Math.floor(xArr[i0] / bucketMs) * bucketMs;
+
+    const flush = () => {
+      if (!buf.length) return;
+      buf.sort((a, b) => a - b);
+      const n = buf.length, mid = n >> 1;
+      buckets.push({
+        x: bStart + bucketMs / 2,
+        min: buf[0],
+        q1: buf[Math.floor(n * 0.25)],
+        med: n & 1 ? buf[mid] : (buf[mid - 1] + buf[mid]) / 2,
+        q3: buf[Math.ceil(n * 0.75) - 1] || buf[n - 1],
+        max: buf[n - 1],
+        n
+      });
+      buf.length = 0;
+    };
+
+    for (let i = i0; i < i1; i++) {
+      const bKey = Math.floor(xArr[i] / bucketMs) * bucketMs;
+      if (bKey !== bStart) { flush(); bStart = bKey; }
+      buf.push(yArr[i]);
+    }
+    flush();
+    return buckets;
+  };
+
+  // ── Stats helpers ──────────────────────────────────────────
+  const sortedSlice = (arr, i0, i1) => {
+    const tmp = new Float64Array(i1 - i0);
+    for (let i = 0; i < tmp.length; i++) tmp[i] = arr[i0 + i];
+    tmp.sort();
+    return tmp;
+  };
+  const medianOf = s => {
+    const n = s.length, m = n >> 1;
+    return n & 1 ? s[m] : (s[m - 1] + s[m]) / 2;
+  };
+  const pctOf = (s, p) => {
+    const idx = (p / 100) * (s.length - 1);
+    const lo = Math.floor(idx), hi = Math.ceil(idx);
+    return lo === hi ? s[lo] : s[lo] + (s[hi] - s[lo]) * (idx - lo);
+  };
+
+  // ── Constants ──────────────────────────────────────────────
+  const HOUR = 3_600_000;
+  const BAND_THRESHOLD = 48;  // hours: above this → band mode
+  const presets = [6, 12, 24, 48, 168, 720];
+  const COL = { dl: '#7eb6f6', ul: '#c982e0', pi: '#f2a93b' };
+  const dataEnd = ts[LEN - 1];
+  let currentH = 48, rangeEnd = dataEnd + 600_000;
+  let rangeStart = rangeEnd - currentH * HOUR;
+  let isLive = true, renderRAF = 0, lastMode = '';
+
+  const pad2 = n => n < 10 ? '0' + n : '' + n;
+  const fmtDate = t => {
+    const d = new Date(t);
+    return `${pad2(d.getDate())}/${pad2(d.getMonth() + 1)} ${pad2(d.getHours())}:${pad2(d.getMinutes())}`;
+  };
+  const fmtSpd = v => v >= 1000
+    ? `${(v / 1000).toFixed(1)}<span class="u">Gb/s</span>`
+    : `${v.toFixed(0)}<span class="u">Mb/s</span>`;
+  const fmtSpd0 = v => v >= 1000 ? (v / 1000).toFixed(1) + ' G' : v.toFixed(0);
+
+  const bsearch = (target, first) => {
+    let lo = 0, hi = LEN - 1, r = first ? LEN : -1;
+    while (lo <= hi) {
+      const m = (lo + hi) >> 1;
+      if (first) { if (ts[m] >= target) { r = m; hi = m - 1; } else lo = m + 1; }
+      else { if (ts[m] <= target) { r = m; lo = m + 1; } else hi = m - 1; }
+    }
+    return r;
+  };
+
+  const filterRange = (s, e) => {
+    const i0 = bsearch(s, true), i1 = bsearch(e, false);
+    return (i0 <= i1 && i0 < LEN) ? [i0, i1 + 1] : null;
+  };
+
+  const bucketSize = () => currentH <= 168 ? 2 * HOUR : currentH <= 720 ? 6 * HOUR : 24 * HOUR;
+
+  // ── Gradient ───────────────────────────────────────────────
+  const mkGrad = (ctx, hex, h) => {
+    const [r, g, b] = hex.slice(1).match(/.{2}/g).map(x => parseInt(x, 16));
+    const grad = ctx.createLinearGradient(0, 0, 0, h);
+    grad.addColorStop(0, `rgba(${r},${g},${b},0.25)`);
+    grad.addColorStop(1, `rgba(${r},${g},${b},0.01)`);
+    return grad;
+  };
+  const rgba = (hex, a) => {
+    const [r, g, b] = hex.slice(1).match(/.{2}/g).map(x => parseInt(x, 16));
+    return `rgba(${r},${g},${b},${a})`;
+  };
+
+  // ── Chart config ───────────────────────────────────────────
+  Chart.defaults.color = '#555';
+  Chart.defaults.borderColor = '#2a2a2d';
+
+  const mono = "'Geist Mono',monospace";
+  const scaleX = {
+    type: 'time',
+    time: { tooltipFormat: 'dd/MM HH:mm', displayFormats: { hour: 'HH:mm', day: 'dd/MM' } },
+    grid: { color: '#1e2228' },
+    ticks: { font: { family: mono, size: 10 }, maxTicksLimit: 12 }
+  };
+  const baseOpts = (ar) => ({
+    responsive: true, maintainAspectRatio: true,
+    aspectRatio: innerWidth < 600 ? 1.5 : ar,
+    animation: false, parsing: false, normalized: true,
+    interaction: { mode: 'index', intersect: false },
+    scales: { x: { ...scaleX } },
+    plugins: { legend: { display: false } }
+  });
+  const tipStyle = {
+    backgroundColor: '#141415', borderColor: '#2a2a2d', borderWidth: 1,
+    titleFont: { family: mono, size: 11 }, bodyFont: { family: mono, size: 11 },
+    padding: 10, cornerRadius: 4
+  };
+
+  // Charts created once, datasets swapped per mode
+  const bwCtx = document.getElementById('bwChart').getContext('2d');
+  const bwH = document.getElementById('bwChart').parentElement.clientHeight || 300;
+  const bwChart = new Chart(bwCtx, {
+    type: 'line', data: { datasets: [] },
+    options: {
+      ...baseOpts(2.8),
+      scales: {
+        x: { ...scaleX },
+        y: { beginAtZero: true, grid: { color: '#1e2228' },
+          ticks: { font: { family: mono, size: 10 }, callback: v => v >= 1000 ? (v / 1000).toFixed(1) + ' Gb/s' : v + ' Mb/s' } }
+      },
+      plugins: { legend: { display: false },
+        tooltip: { ...tipStyle, callbacks: {
+          label: c => {
+            const ds = c.dataset;
+            if (ds._isBand) return null; // hide band tooltip lines
+            return `${ds.label}: ${c.parsed.y.toFixed(1)} Mb/s`;
+          }
+        }, filter: c => c.dataset.label && !c.dataset._isBand
         }
-        var series = RAW_DATA.results[0].series;
-        if (!series || !series[0] || !series[0].values || series[0].values.length === 0) {
-            document.getElementById('statsRow').innerHTML = '<div class="no-data">Aucune donn\u00e9e disponible</div>';
-            return;
+      }
+    }
+  });
+
+  const piCtx = document.getElementById('piChart').getContext('2d');
+  const piH = document.getElementById('piChart').parentElement.clientHeight || 200;
+  const piChart = new Chart(piCtx, {
+    type: 'line', data: { datasets: [] },
+    options: {
+      ...baseOpts(4),
+      scales: {
+        x: { ...scaleX },
+        y: { beginAtZero: true, grid: { color: '#1e2228' },
+          ticks: { font: { family: mono, size: 10 }, callback: v => v + ' ms' } }
+      },
+      plugins: { legend: { display: false },
+        tooltip: { ...tipStyle, callbacks: {
+          label: c => {
+            if (c.dataset._isBand) return null;
+            return `${c.parsed.y.toFixed(1)} ms`;
+          }
+        }, filter: c => !c.dataset._isBand
         }
+      }
+    }
+  });
 
-        var cols = series[0].columns;
-        var iTime = cols.indexOf('time'), iDl = cols.indexOf('download_bandwidth');
-        var iUl = cols.indexOf('upload_bandwidth'), iPing = cols.indexOf('ping_latency');
+  // ── Dataset factories ──────────────────────────────────────
+  const dsLine = {
+    tension: 0.15, pointRadius: 0,
+    pointHitRadius: 6, pointHoverRadius: 3, borderWidth: 1.5
+  };
 
-        var allData = series[0].values.map(function(r) {
-            var t = new Date(r[iTime]);
-            return { ts: t.getTime(), dl: r[iDl] / 125000, ul: r[iUl] / 125000, pi: r[iPing] };
-        });
+  // Band datasets: Q3 fill→Q1, Q1 invisible, median solid
+  const makeBandDs = (buckets, color, label) => [
+    { // Q3 upper boundary → fills down to Q1
+      ...dsLine, data: buckets.map(b => ({ x: b.x, y: b.q3 })),
+      borderColor: 'transparent', borderWidth: 0, pointRadius: 0,
+      backgroundColor: rgba(color, 0.15), fill: '+1', _isBand: true,
+      tension: 0.3
+    },
+    { // Q1 lower boundary
+      ...dsLine, data: buckets.map(b => ({ x: b.x, y: b.q1 })),
+      borderColor: rgba(color, 0.3), borderWidth: 0.5, pointRadius: 0,
+      fill: false, _isBand: true, tension: 0.3
+    },
+    { // Median line
+      ...dsLine, data: buckets.map(b => ({ x: b.x, y: b.med })),
+      borderColor: color, borderWidth: 2, pointRadius: 0,
+      fill: false, label, tension: 0.3
+    },
+    { // Min whisker (very faint)
+      ...dsLine, data: buckets.map(b => ({ x: b.x, y: b.min })),
+      borderColor: rgba(color, 0.12), borderWidth: 1, pointRadius: 0,
+      borderDash: [2, 3], fill: false, _isBand: true, tension: 0.3
+    },
+    { // Max whisker (very faint)
+      ...dsLine, data: buckets.map(b => ({ x: b.x, y: b.max })),
+      borderColor: rgba(color, 0.12), borderWidth: 1, pointRadius: 0,
+      borderDash: [2, 3], fill: false, _isBand: true, tension: 0.3
+    }
+  ];
 
-        var allXY = {
-            dl: allData.map(function(d) { return { x: d.ts, y: d.dl }; }),
-            ul: allData.map(function(d) { return { x: d.ts, y: d.ul }; }),
-            pi: allData.map(function(d) { return { x: d.ts, y: d.pi }; })
+  const makeLineDs = (xArr, yArr, i0, i1, color, label, ctx, h) => [{
+    ...dsLine, label, data: lttb(xArr, yArr, i0, i1, MAX_PTS),
+    borderColor: color, backgroundColor: mkGrad(ctx, color, h), fill: true
+  }];
+
+  // ── Stat card builder ──────────────────────────────────────
+  const statCard = (cls, label, mainVal, items, nPts, timeRange) =>
+    `<div class="stat ${cls}">
+      <div class="v">${mainVal}</div>
+      <div class="l">${label} <span style="font-size:.85em;opacity:.5">m\u00e9diane</span></div>
+      <dl class="sg">${items.map(([k, v]) => `<dt>${k}</dt><dd>${v}</dd>`).join('')}</dl>
+      <div class="pts">${timeRange} \u00b7 ${nPts} pts</div>
+    </div>`;
+
+  // ── Band tooltip (shows bucket stats) ──────────────────────
+  const bandTooltipBw = {
+    ...tipStyle,
+    filter: c => !c.dataset._isBand,
+    callbacks: {
+      label: c => {
+        if (c.dataset._isBand) return null;
+        const idx = c.dataIndex;
+        const label = c.dataset.label;
+        const val = c.parsed.y.toFixed(1);
+        return `${label} med: ${val} Mb/s`;
+      }
+    }
+  };
+  const bandTooltipPi = {
+    ...tipStyle,
+    filter: c => !c.dataset._isBand,
+    callbacks: {
+      label: c => c.dataset._isBand ? null : `med: ${c.parsed.y.toFixed(1)} ms`
+    }
+  };
+
+  // ── Render ─────────────────────────────────────────────────
+  const doRender = () => {
+    const rng = filterRange(rangeStart, rangeEnd);
+    const mode = currentH > BAND_THRESHOLD ? 'band' : 'line';
+
+    if (!rng) {
+      statsEl.innerHTML = '<div class="no-data" style="grid-column:1/-1">Aucune donn\u00e9e sur cette p\u00e9riode</div>';
+      document.getElementById('bwLeg').innerHTML = '';
+      document.getElementById('piLeg').innerHTML = '';
+      bwChart.data.datasets = [];
+      piChart.data.datasets = [];
+    } else {
+      const [i0, i1] = rng;
+      const n = i1 - i0;
+
+      // ── Stats ──────────────────────────────────────────────
+      let dlS = 0, ulS = 0, piS = 0;
+      let dlMx = -Infinity, dlMn = Infinity, ulMx = -Infinity, ulMn = Infinity;
+      let piMn = Infinity, piMx = -Infinity;
+      for (let i = i0; i < i1; i++) {
+        const d = dl[i], u = ul[i], p = pi[i];
+        dlS += d; ulS += u; piS += p;
+        if (d > dlMx) dlMx = d; if (d < dlMn) dlMn = d;
+        if (u > ulMx) ulMx = u; if (u < ulMn) ulMn = u;
+        if (p > piMx) piMx = p; if (p < piMn) piMn = p;
+      }
+      const dlAvg = dlS / n, ulAvg = ulS / n, piAvg = piS / n;
+      const dlSorted = sortedSlice(dl, i0, i1);
+      const ulSorted = sortedSlice(ul, i0, i1);
+      const piSorted = sortedSlice(pi, i0, i1);
+      const dlMed = medianOf(dlSorted), ulMed = medianOf(ulSorted), piMed = medianOf(piSorted);
+      const piP95 = pctOf(piSorted, 95);
+
+      const trLabel = `${fmtDate(rangeStart)} \u2192 ${fmtDate(rangeEnd)}`;
+
+      statsEl.innerHTML =
+        statCard('dl', 'Download', fmtSpd(dlMed), [
+          ['min', fmtSpd0(dlMn)], ['avg', fmtSpd0(dlAvg)],
+          ['max', fmtSpd0(dlMx)], ['last', fmtSpd0(dl[i1 - 1])]
+        ], n, trLabel)
+        + statCard('ul', 'Upload', fmtSpd(ulMed), [
+          ['min', fmtSpd0(ulMn)], ['avg', fmtSpd0(ulAvg)],
+          ['max', fmtSpd0(ulMx)], ['last', fmtSpd0(ul[i1 - 1])]
+        ], n, trLabel)
+        + statCard('pi', 'Ping', `${piMed.toFixed(1)}<span class="u">ms</span>`, [
+          ['min', piMn.toFixed(1)], ['med', piMed.toFixed(1)],
+          ['p95', piP95.toFixed(1)], ['max', piMx.toFixed(1)]
+        ], n, trLabel);
+
+      // ── Legend ─────────────────────────────────────────────
+      const bandLabel = mode === 'band' ? ' <span style="color:var(--text3)">(m\u00e9diane + IQR)</span>' : '';
+      document.getElementById('bwLeg').innerHTML = `
+        <span><i style="background:${COL.dl}"></i>download${bandLabel}</span>
+        <span><i style="background:${COL.ul}"></i>upload</span>`;
+      document.getElementById('piLeg').innerHTML = `
+        <span><i style="background:${COL.pi}"></i>latency${bandLabel}</span>`;
+
+      // ── Datasets ───────────────────────────────────────────
+      if (mode === 'band') {
+        const bMs = bucketSize();
+        const dlB = bucketize(ts, dl, i0, i1, bMs);
+        const ulB = bucketize(ts, ul, i0, i1, bMs);
+        const piB = bucketize(ts, pi, i0, i1, bMs);
+
+        bwChart.data.datasets = [
+          ...makeBandDs(dlB, COL.dl, 'download'),
+          ...makeBandDs(ulB, COL.ul, 'upload')
+        ];
+        bwChart.options.plugins.tooltip = bandTooltipBw;
+
+        piChart.data.datasets = makeBandDs(piB, COL.pi, 'latency');
+        piChart.options.plugins.tooltip = bandTooltipPi;
+      } else {
+        bwChart.data.datasets = [
+          ...makeLineDs(ts, dl, i0, i1, COL.dl, 'download', bwCtx, bwH),
+          ...makeLineDs(ts, ul, i0, i1, COL.ul, 'upload', bwCtx, bwH)
+        ];
+        bwChart.options.plugins.tooltip = {
+          ...tipStyle,
+          callbacks: { label: c => `${c.dataset.label}: ${c.parsed.y.toFixed(1)} Mb/s` }
         };
 
-        // LTTB downsampling
-        var MAX_PTS = 800;
-        function lttb(data, n) {
-            var len = data.length;
-            if (len <= n) return data;
-            var out = [data[0]], bs = (len - 2) / (n - 2), a = 0;
-            for (var i = 0; i < n - 2; i++) {
-                var s = Math.floor((i + 1) * bs) + 1, e = Math.min(Math.floor((i + 2) * bs) + 1, len);
-                var ns = Math.min(Math.floor((i + 2) * bs) + 1, len - 1);
-                var ne = Math.min(Math.floor((i + 3) * bs) + 1, len);
-                var ax = 0, ay = 0, c = 0;
-                for (var j = ns; j < ne; j++) { ax += data[j].x; ay += data[j].y; c++; }
-                if (c) { ax /= c; ay /= c; }
-                var ma = -1, bi = s, px = data[a].x, py = data[a].y;
-                for (var j = s; j < e; j++) {
-                    var ar = Math.abs((px - ax) * (data[j].y - py) - (px - data[j].x) * (ay - py));
-                    if (ar > ma) { ma = ar; bi = j; }
-                }
-                out.push(data[bi]); a = bi;
-            }
-            out.push(data[len - 1]);
-            return out;
-        }
+        piChart.data.datasets = makeLineDs(ts, pi, i0, i1, COL.pi, 'latency', piCtx, piH);
+        piChart.options.plugins.tooltip = {
+          ...tipStyle,
+          callbacks: { label: c => `${c.parsed.y.toFixed(1)} ms` }
+        };
+      }
+    }
 
-        var dataEnd = allData[allData.length - 1].ts;
-        var HOUR = 3600000;
-        var rangePresets = [6, 12, 24, 48, 168, 720];
-        var currentHours = 48;
-        var rangeEnd = dataEnd + 600000;
-        var rangeStart = rangeEnd - currentHours * HOUR;
-        var isLive = true;
+    bwChart.options.scales.x.min = rangeStart;
+    bwChart.options.scales.x.max = rangeEnd;
+    bwChart.update('none');
 
-        // Colors matching Grafana
-        var COL_DL = '#7eb6f6';  // blue
-        var COL_UL = '#c982e0';  // purple/pink
-        var COL_PI = '#f2a93b';  // yellow/orange
+    piChart.options.scales.x.min = rangeStart;
+    piChart.options.scales.x.max = rangeEnd;
+    piChart.update('none');
 
-        Chart.defaults.color = '#6e7681';
-        Chart.defaults.borderColor = '#2a2e35';
+    document.getElementById('rangeLabel').textContent = `${fmtDate(rangeStart)}  \u2192  ${fmtDate(rangeEnd)}`;
+    document.querySelectorAll('.rb').forEach(b =>
+      b.classList.toggle('on', parseInt(b.dataset.hours) === currentH));
+    lastMode = mode;
+  };
 
-        function makeGradient(ctx, hex, h) {
-            var m = hex.replace('#','').match(/.{2}/g).map(function(x) { return parseInt(x,16); });
-            var g = ctx.createLinearGradient(0, 0, 0, h);
-            g.addColorStop(0, 'rgba(' + m + ',0.35)');
-            g.addColorStop(1, 'rgba(' + m + ',0.03)');
-            return g;
-        }
+  const render = () => {
+    cancelAnimationFrame(renderRAF);
+    renderRAF = requestAnimationFrame(doRender);
+  };
 
-        // Bandwidth chart (2 datasets: download + upload overlaid)
-        var bwCtx = document.getElementById('bandwidthChart').getContext('2d');
-        var bwH = document.getElementById('bandwidthChart').parentElement.clientHeight || 300;
-        var bwChart = new Chart(bwCtx, {
-            type: 'line',
-            data: {
-                datasets: [
-                    {
-                        label: 'download', data: [], order: 2,
-                        borderColor: COL_DL, backgroundColor: makeGradient(bwCtx, COL_DL, bwH),
-                        fill: true, tension: 0.2, pointRadius: 0,
-                        pointHitRadius: 6, pointHoverRadius: 3, borderWidth: 1.5
-                    },
-                    {
-                        label: 'upload', data: [], order: 1,
-                        borderColor: COL_UL, backgroundColor: makeGradient(bwCtx, COL_UL, bwH),
-                        fill: true, tension: 0.2, pointRadius: 0,
-                        pointHitRadius: 6, pointHoverRadius: 3, borderWidth: 1.5
-                    }
-                ]
-            },
-            options: {
-                responsive: true, maintainAspectRatio: true,
-                aspectRatio: window.innerWidth < 600 ? 1.5 : 2.8,
-                animation: false, parsing: false, normalized: true,
-                interaction: { mode: 'index', intersect: false },
-                scales: {
-                    x: {
-                        type: 'time',
-                        time: { tooltipFormat: 'dd/MM HH:mm', displayFormats: { hour: 'HH:mm', day: 'dd/MM' } },
-                        grid: { color: '#1e2228' }
-                    },
-                    y: {
-                        beginAtZero: true, grid: { color: '#1e2228' },
-                        ticks: { callback: function(v) { return v >= 1000 ? (v/1000).toFixed(1) + ' Gb/s' : v + ' Mb/s'; } }
-                    }
-                },
-                plugins: {
-                    legend: { display: false },
-                    tooltip: { backgroundColor: '#181b1f', borderColor: '#2a2e35', borderWidth: 1,
-                        callbacks: { label: function(c) { return c.dataset.label + ': ' + c.parsed.y.toFixed(1) + ' Mb/s'; } }
-                    }
-                }
-            }
-        });
+  // ── Time controls ──────────────────────────────────────────
+  const setRange = h => {
+    currentH = h;
+    if (isLive) rangeEnd = dataEnd + 600_000;
+    rangeStart = rangeEnd - currentH * HOUR;
+    render();
+  };
 
-        // Ping chart
-        var piCtx = document.getElementById('pingChart').getContext('2d');
-        var piH = document.getElementById('pingChart').parentElement.clientHeight || 200;
-        var piChart = new Chart(piCtx, {
-            type: 'line',
-            data: {
-                datasets: [{
-                    label: 'latency', data: [],
-                    borderColor: COL_PI, backgroundColor: makeGradient(piCtx, COL_PI, piH),
-                    fill: true, tension: 0.2, pointRadius: 0,
-                    pointHitRadius: 6, pointHoverRadius: 3, borderWidth: 1.5
-                }]
-            },
-            options: {
-                responsive: true, maintainAspectRatio: true,
-                aspectRatio: window.innerWidth < 600 ? 1.5 : 4,
-                animation: false, parsing: false, normalized: true,
-                interaction: { mode: 'index', intersect: false },
-                scales: {
-                    x: {
-                        type: 'time',
-                        time: { tooltipFormat: 'dd/MM HH:mm', displayFormats: { hour: 'HH:mm', day: 'dd/MM' } },
-                        grid: { color: '#1e2228' }
-                    },
-                    y: {
-                        beginAtZero: true, grid: { color: '#1e2228' },
-                        ticks: { callback: function(v) { return v + ' ms'; } }
-                    }
-                },
-                plugins: {
-                    legend: { display: false },
-                    tooltip: { backgroundColor: '#181b1f', borderColor: '#2a2e35', borderWidth: 1,
-                        callbacks: { label: function(c) { return c.parsed.y.toFixed(1) + ' ms'; } }
-                    }
-                }
-            }
-        });
+  const shift = dir => {
+    const s = currentH * HOUR * 0.5 * dir;
+    rangeStart += s; rangeEnd += s;
+    isLive = rangeEnd >= dataEnd;
+    render();
+  };
 
-        // Helpers
-        function pad2(n) { return n < 10 ? '0' + n : '' + n; }
-        function fmtDate(ts) {
-            var d = new Date(ts);
-            return pad2(d.getDate()) + '/' + pad2(d.getMonth()+1) + ' ' + pad2(d.getHours()) + ':' + pad2(d.getMinutes());
-        }
-        function bsearch(arr, ts, first) {
-            var lo = 0, hi = arr.length - 1, r = first ? arr.length : -1;
-            while (lo <= hi) {
-                var m = (lo + hi) >> 1;
-                if (first) { if (arr[m].ts >= ts) { r = m; hi = m-1; } else lo = m+1; }
-                else { if (arr[m].ts <= ts) { r = m; lo = m+1; } else hi = m-1; }
-            }
-            return r;
-        }
-        function filterRange(s, e) {
-            var i0 = bsearch(allData, s, true), i1 = bsearch(allData, e, false);
-            return (i0 <= i1 && i0 < allData.length) ? [i0, i1+1] : null;
-        }
+  document.querySelectorAll('.rb').forEach(b =>
+    b.addEventListener('click', () => { isLive = true; setRange(parseInt(b.dataset.hours)); }));
+  document.getElementById('btnBack').addEventListener('click', () => shift(-1));
+  document.getElementById('btnFwd').addEventListener('click', () => shift(1));
+  document.getElementById('btnZoomIn').addEventListener('click', () => {
+    const i = presets.indexOf(currentH);
+    if (i > 0) setRange(presets[i - 1]);
+    else if (currentH > presets[0]) setRange(presets[0]);
+  });
+  document.getElementById('btnZoomOut').addEventListener('click', () => {
+    const i = presets.indexOf(currentH);
+    if (i >= 0 && i < presets.length - 1) setRange(presets[i + 1]);
+    else if (i < 0) { for (const p of presets) { if (p > currentH) { setRange(p); break; } } }
+  });
+  document.addEventListener('keydown', e => {
+    if (e.key === 'ArrowLeft') shift(-1);
+    else if (e.key === 'ArrowRight') shift(1);
+    else if (e.key === '+' || e.key === '=') document.getElementById('btnZoomIn').click();
+    else if (e.key === '-') document.getElementById('btnZoomOut').click();
+  });
 
-        function render() {
-            var rng = filterRange(rangeStart, rangeEnd);
-
-            if (!rng) {
-                document.getElementById('statsRow').innerHTML =
-                    '<div class="no-data" style="grid-column:1/-1">Aucune donn\u00e9e sur cette p\u00e9riode</div>';
-                document.getElementById('bwLegend').innerHTML = '';
-                document.getElementById('pingLegend').innerHTML = '';
-            } else {
-                var i0 = rng[0], i1 = rng[1], n = i1 - i0;
-                var dlS=0, ulS=0, piS=0, dlMx=0, dlMn=1e9, ulMx=0, ulMn=1e9, piMn=1e9, piMx=0;
-                var lastDl=0, lastUl=0;
-                for (var i = i0; i < i1; i++) {
-                    var d = allData[i];
-                    dlS += d.dl; ulS += d.ul; piS += d.pi;
-                    if (d.dl > dlMx) dlMx = d.dl; if (d.dl < dlMn) dlMn = d.dl;
-                    if (d.ul > ulMx) ulMx = d.ul; if (d.ul < ulMn) ulMn = d.ul;
-                    if (d.pi > piMx) piMx = d.pi; if (d.pi < piMn) piMn = d.pi;
-                    lastDl = d.dl; lastUl = d.ul;
-                }
-                var dlAvg = dlS/n, ulAvg = ulS/n, piAvg = piS/n;
-
-                document.getElementById('statsRow').innerHTML =
-                    '<div class="stat-panel ping"><div class="stat-title">Ping</div>'
-                    + '<div class="stat-value">' + piAvg.toFixed(1) + '<span class="stat-unit">ms</span></div>'
-                    + '<div class="stat-sub">min ' + piMn.toFixed(1) + ' &middot; max ' + piMx.toFixed(1) + '</div></div>'
-                    + '<div class="stat-panel download"><div class="stat-title">Download</div>'
-                    + '<div class="stat-value">' + lastDl.toFixed(0) + '<span class="stat-unit">Mb/s</span></div>'
-                    + '<div class="stat-sub">moy ' + dlAvg.toFixed(0) + ' &middot; max ' + dlMx.toFixed(0) + '</div></div>'
-                    + '<div class="stat-panel upload"><div class="stat-title">Upload</div>'
-                    + '<div class="stat-value">' + lastUl.toFixed(0) + '<span class="stat-unit">Mb/s</span></div>'
-                    + '<div class="stat-sub">moy ' + ulAvg.toFixed(0) + ' &middot; max ' + ulMx.toFixed(0) + '</div></div>';
-
-                document.getElementById('bwLegend').innerHTML =
-                    '<span class="leg-item"><span class="leg-color" style="background:' + COL_DL + '"></span> download'
-                    + '  Max: ' + dlMx.toFixed(0) + '  Min: ' + dlMn.toFixed(1) + '</span>'
-                    + '<span class="leg-item"><span class="leg-color" style="background:' + COL_UL + '"></span> upload'
-                    + '  Max: ' + ulMx.toFixed(0) + '  Min: ' + ulMn.toFixed(0) + '</span>';
-
-                document.getElementById('pingLegend').innerHTML =
-                    '<span class="leg-item"><span class="leg-color" style="background:' + COL_PI + '"></span> latency'
-                    + '  Avg: ' + piAvg.toFixed(1) + ' ms  Max: ' + piMx.toFixed(1) + ' ms</span>';
-            }
-
-            var sl = rng || [0, 0];
-            bwChart.data.datasets[0].data = lttb(allXY.dl.slice(sl[0], sl[1]), MAX_PTS);
-            bwChart.data.datasets[1].data = lttb(allXY.ul.slice(sl[0], sl[1]), MAX_PTS);
-            bwChart.options.scales.x.min = rangeStart;
-            bwChart.options.scales.x.max = rangeEnd;
-            bwChart.update('none');
-
-            piChart.data.datasets[0].data = lttb(allXY.pi.slice(sl[0], sl[1]), MAX_PTS);
-            piChart.options.scales.x.min = rangeStart;
-            piChart.options.scales.x.max = rangeEnd;
-            piChart.update('none');
-
-            document.getElementById('rangeLabel').textContent =
-                fmtDate(rangeStart) + '  \u2192  ' + fmtDate(rangeEnd);
-            document.querySelectorAll('.range-btn').forEach(function(b) {
-                b.classList.toggle('active', parseInt(b.dataset.hours) === currentHours);
-            });
-        }
-
-        function setRange(h) {
-            currentHours = h;
-            if (isLive) rangeEnd = dataEnd + 600000;
-            rangeStart = rangeEnd - currentHours * HOUR;
-            render();
-        }
-        function shift(dir) {
-            var s = currentHours * HOUR * 0.5 * dir;
-            rangeStart += s; rangeEnd += s;
-            isLive = rangeEnd >= dataEnd;
-            render();
-        }
-
-        document.querySelectorAll('.range-btn').forEach(function(b) {
-            b.addEventListener('click', function() { isLive = true; setRange(parseInt(this.dataset.hours)); });
-        });
-        document.getElementById('btnBack').addEventListener('click', function() { shift(-1); });
-        document.getElementById('btnForward').addEventListener('click', function() { shift(1); });
-        document.getElementById('btnZoomIn').addEventListener('click', function() {
-            var idx = rangePresets.indexOf(currentHours);
-            if (idx > 0) setRange(rangePresets[idx-1]);
-            else if (currentHours > rangePresets[0]) setRange(rangePresets[0]);
-        });
-        document.getElementById('btnZoomOut').addEventListener('click', function() {
-            var idx = rangePresets.indexOf(currentHours);
-            if (idx >= 0 && idx < rangePresets.length - 1) setRange(rangePresets[idx+1]);
-            else if (idx < 0) {
-                for (var i = 0; i < rangePresets.length; i++) {
-                    if (rangePresets[i] > currentHours) { setRange(rangePresets[i]); break; }
-                }
-            }
-        });
-        document.addEventListener('keydown', function(e) {
-            if (e.key === 'ArrowLeft') shift(-1);
-            else if (e.key === 'ArrowRight') shift(1);
-            else if (e.key === '+' || e.key === '=') document.getElementById('btnZoomIn').click();
-            else if (e.key === '-') document.getElementById('btnZoomOut').click();
-        });
-
-        render();
-    })();
-    </script>
+  doRender();
+})();
+</script>
 </body>
 </html>

--- a/scripts/preview-dev.sh
+++ b/scripts/preview-dev.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Preview the monitoring page locally using data from the live GitHub Pages.
+# Usage: bash scripts/preview-dev.sh [port]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEMPLATE="$SCRIPT_DIR/gh-pages/index.template.html"
+PORT="${1:-8080}"
+
+BUILD_DIR=$(mktemp -d)
+trap 'rm -rf "$BUILD_DIR"' EXIT
+
+echo "╔══════════════════════════════════════════╗"
+echo "║  Preview Dev — GitHub Pages Monitoring   ║"
+echo "╚══════════════════════════════════════════╝"
+echo ""
+
+# ── 1. Fetch live data ────────────────────────────────────
+echo "── Fetching data from live GitHub Pages ──"
+
+curl -sf "https://yoyonel.github.io/rpi-internet-monitoring/" -o "$BUILD_DIR/live.html" \
+    || { echo "ERROR: Could not fetch live page. Check your connection."; exit 1; }
+
+python3 << PYEOF
+import re, json
+
+with open("$BUILD_DIR/live.html") as f:
+    html = f.read()
+
+m = re.search(r'(?:var|const)\s+RAW_DATA\s*=\s*({.*?});', html, re.DOTALL)
+if not m:
+    print("  ERROR: Could not extract speedtest data"); exit(1)
+with open("$BUILD_DIR/data.json", "w") as f:
+    f.write(m.group(1))
+pts = len(json.loads(m.group(1)).get('results', [{}])[0].get('series', [{}])[0].get('values', []))
+
+m2 = re.search(r'(?:var|const)\s+ALERTS\s*=\s*(\[.*?\]);', html, re.DOTALL)
+if not m2:
+    print("  ERROR: Could not extract alerts data"); exit(1)
+with open("$BUILD_DIR/alerts.json", "w") as f:
+    f.write(m2.group(1))
+alerts_count = len(json.loads(m2.group(1)))
+
+print(f"  → {pts} data points, {alerts_count} alerts")
+PYEOF
+
+# ── 2. Build page from template ──────────────────────────
+echo ""
+echo "── Building page from template ──"
+
+python3 << PYEOF
+from datetime import datetime
+
+with open("$TEMPLATE") as f:
+    html = f.read()
+with open("$BUILD_DIR/data.json") as f:
+    data = f.read()
+with open("$BUILD_DIR/alerts.json") as f:
+    alerts = f.read()
+
+now = datetime.now().strftime('%d/%m/%Y %H:%M')
+gen = datetime.now().strftime('%d/%m/%Y à %H:%M:%S')
+
+html = html.replace('"__SPEEDTEST_DATA__"', data)
+html = html.replace('"__ALERTS_DATA__"', alerts)
+html = html.replace('__LAST_UPDATE__', now)
+html = html.replace('__GENERATED_AT__', gen)
+
+with open("$BUILD_DIR/index.html", "w") as f:
+    f.write(html)
+print(f"  → index.html ({len(html):,} bytes)")
+
+assert '__SPEEDTEST_DATA__' not in html, "Data injection failed"
+assert '__ALERTS_DATA__' not in html, "Alerts injection failed"
+PYEOF
+
+# ── 3. Serve ─────────────────────────────────────────────
+echo ""
+echo "── Serving on http://localhost:${PORT} ──"
+echo "  Press Ctrl+C to stop"
+echo ""
+cd "$BUILD_DIR" && python3 -m http.server "$PORT"

--- a/systemd/publish-gh-pages.service
+++ b/systemd/publish-gh-pages.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Publish monitoring page to GitHub Pages
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/rpi-internet-monitoring
+ExecStart=/usr/bin/bash scripts/publish-gh-pages.sh 30
+TimeoutStartSec=120
+Environment=HOME=%h

--- a/systemd/publish-gh-pages.timer
+++ b/systemd/publish-gh-pages.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Publish GitHub Pages every 10 minutes
+
+[Timer]
+OnCalendar=*:0/10
+RandomizedDelaySec=60
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/systemd/speedtest.service
+++ b/systemd/speedtest.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run internet speedtest and store result in InfluxDB
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/rpi-internet-monitoring
+ExecStart=/usr/bin/docker compose run --rm speedtest
+TimeoutStartSec=300
+# Avoid overlapping runs
+ExecCondition=/bin/sh -c '! docker ps --format "{{.Names}}" | grep -q speedtest'

--- a/systemd/speedtest.timer
+++ b/systemd/speedtest.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Speedtest every 10 minutes
+
+[Timer]
+OnCalendar=*:0/10
+RandomizedDelaySec=30
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Résumé

Refonte complète de la page GitHub Pages de monitoring.

<img width="826" height="964" alt="image" src="https://github.com/user-attachments/assets/51628971-43a5-4f50-89c9-57e50ae9360a" />

### Changements

**Design** — Thème sombre inspiré de [tsbench](https://mibayy.github.io/tsbench/) : police Geist, CSS variables, nav sticky avec backdrop-filter.

**Stats détaillées** — Chaque carte affiche la **médiane** comme valeur principale, avec sous-métriques (min / avg / max / last) recalculées dynamiquement sur la fenêtre de temps active. Plage temporelle et nombre de points affichés.

**Rendu dual-mode adaptatif** :
- **≤ 48h** : line chart classique (LTTB 600 pts max, gradient fill)
- **\> 48h** : **IQR band chart** — bandes Q1↔Q3 + ligne médiane + whiskers min/max par bucket temporel. Rendu instantané même sur 30 jours.

**Alertes** — Températures converties de m°C → °C. Badges ok/firing/pending.

**Performance** — Float64Array, LTTB sur typed arrays, requestAnimationFrame debounce, fill désactivé en mode band.

**Dev workflow** — Nouveau `just preview-dev` pour travailler sur le template sans RPi (fetch les données live de la GH Pages).

**CI** — Workflow GitHub Actions pour preview Surge.sh automatique sur chaque PR touchant `gh-pages/`.

### Commits (SoC)
- `feat:` Redesign template HTML/CSS/JS
- `feat:` Script preview-dev + recette Justfile
- `docs:` README mis à jour
- `ci:` Workflow surge.sh PR preview

### Test
```bash
just preview-dev   # ouvrir http://localhost:8080 et tester 6h/12h/24h/2j/7j/30j
```