### PR TITLE
feat: drag-to-zoom, time range picker & middle-click pan

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,47 @@
+repos:
+  # ── Shell ──────────────────────────────────────────────
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.10.0
+    hooks:
+      - id: shellcheck
+        args: [-x]
+
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.11.0-1
+    hooks:
+      - id: shfmt
+        args: [-i, '4', -ci]
+
+  # ── Dockerfile ─────────────────────────────────────────
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.12.0
+    hooks:
+      - id: hadolint
+
+  # ── YAML ───────────────────────────────────────────────
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.37.1
+    hooks:
+      - id: yamllint
+
+  # ── Prettier (HTML, CSS, JS, JSON, MD, YAML) ──────────
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v4.0.0-alpha.8
+    hooks:
+      - id: prettier
+        args: [--ignore-unknown]
+        types_or:
+          - html
+          - css
+          - javascript
+          - json
+          - markdown
+          - yaml
+        exclude: ^(grafana|speedtest|telegraf)/
+
+  # ── Python ─────────────────────────────────────────────
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.6
+    hooks:
+      - id: ruff
+      - id: ruff-format

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+# Grafana auto-generated dashboards and provisioning
+grafana/
+speedtest/
+telegraf/
+
+# Build artifacts
+test-results/
+node_modules/

--- a/Justfile
+++ b/Justfile
@@ -138,6 +138,10 @@ check:
 
 # ── Utilities ───────────────────────────────────────────
 
+# Install git hooks (pre-commit: lint, pre-push: E2E tests)
+install-hooks:
+    bash scripts/install-hooks.sh
+
 # Show alert rules and their current state
 alerts:
     bash scripts/alerts.sh {{ project_dir }}

--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ Page statique publique avec les résultats speedtest des 30 derniers jours :
 - **Stats détaillées** : chaque carte affiche la **médiane** comme valeur principale + sous-métriques (min / avg / max / last pour bandwidth, min / med / p95 / max pour ping), nombre de points et plage temporelle active
 - **Alertes RPi** : état des 6 alertes Grafana avec badges ok/firing/pending, températures converties en °C
 - **Drag-to-zoom** : sélection au clic-glissé sur les graphiques pour zoomer sur une plage temporelle (style Grafana). Les deux charts se synchronisent automatiquement. Double-clic pour revenir à la vue 48 h live
+- **Sélecteur de plage temporelle** (style Grafana) : clic sur la plage affichée ouvre un panneau avec calendrier, entrées From/To absolues, présets relatifs (5 min → 30 jours), et historique des plages récentes
 
 ### Rendu dual-mode adaptatif
 

--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Page statique publique avec les résultats speedtest des 30 derniers jours :
 - **Thème sombre** inspiré de [tsbench](https://mibayy.github.io/tsbench/) : CSS variables, police Geist + Geist Mono (Google Fonts), `backdrop-filter` nav, panels `border-radius:8px`
 - **Stats détaillées** : chaque carte affiche la **médiane** comme valeur principale + sous-métriques (min / avg / max / last pour bandwidth, min / med / p95 / max pour ping), nombre de points et plage temporelle active
 - **Alertes RPi** : état des 6 alertes Grafana avec badges ok/firing/pending, températures converties en °C
+- **Drag-to-zoom** : sélection au clic-glissé sur les graphiques pour zoomer sur une plage temporelle (style Grafana). Les deux charts se synchronisent automatiquement. Double-clic pour revenir à la vue 48 h live
 
 ### Rendu dual-mode adaptatif
 
@@ -307,6 +308,7 @@ Le mode band chart est inspiré des boxplots : au lieu de tracer des milliers de
 | Technologie                                                                                                              | Usage                                              |
 | ------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
 | [Chart.js 4](https://www.chartjs.org/) + [chartjs-adapter-date-fns](https://github.com/chartjs/chartjs-adapter-date-fns) | Graphiques temps-réel                              |
+| [chartjs-plugin-zoom](https://www.chartjs.org/chartjs-plugin-zoom/) + [Hammer.js](https://hammerjs.github.io/)           | Drag-to-zoom sur l'axe X (sélection brush)         |
 | [LTTB](https://skemman.is/bitstream/1946/15343/3/SS_MSthesis.pdf)                                                        | Downsampling préservant les pics                   |
 | Float64Array                                                                                                             | Stockage mémoire compact, itération cache-friendly |
 | requestAnimationFrame                                                                                                    | Debounce du rendering                              |

--- a/README.md
+++ b/README.md
@@ -135,11 +135,21 @@ Les timers remplacent le crontab : la configuration est versionnée dans `system
 
 ### Utilitaires
 
-| Commande            | Description                  |
-| ------------------- | ---------------------------- |
-| `just alerts`       | État des alertes (✅/🔴)     |
-| `just influx-shell` | Shell InfluxDB interactif    |
-| `just shell <svc>`  | Shell bash dans un container |
+| Commande             | Description                                    |
+| -------------------- | ---------------------------------------------- |
+| `just alerts`        | État des alertes (✅/🔴)                       |
+| `just influx-shell`  | Shell InfluxDB interactif                      |
+| `just shell <svc>`   | Shell bash dans un container                   |
+| `just install-hooks` | Installe les git hooks (pre-commit + pre-push) |
+
+### Git hooks
+
+Installer avec `just install-hooks`. Deux hooks sont fournis :
+
+| Hook         | Déclencheur  | Action                                                                                          |
+| ------------ | ------------ | ----------------------------------------------------------------------------------------------- |
+| `pre-commit` | `git commit` | Lint & format check sur les fichiers stagés (sh, py, yaml, html, css, js, json, md, Dockerfile) |
+| `pre-push`   | `git push`   | E2E tests Playwright (démarre un serveur preview si nécessaire)                                 |
 
 ## Configuration
 
@@ -291,7 +301,10 @@ Page statique publique avec les résultats speedtest des 30 derniers jours :
 
 - **Thème sombre** inspiré de [tsbench](https://mibayy.github.io/tsbench/) : CSS variables, police Geist + Geist Mono (Google Fonts), `backdrop-filter` nav, panels `border-radius:8px`
 - **Stats détaillées** : chaque carte affiche la **médiane** comme valeur principale + sous-métriques (min / avg / max / last pour bandwidth, min / med / p95 / max pour ping), nombre de points et plage temporelle active
-- **Alertes RPi** : état des 6 alertes Grafana avec badges ok/firing/pending, températures converties en °C
+- **Alertes RPi** : état des 6 alertes Grafana avec badges ok/firing/pending, températures converties en °C, horodatage de la dernière évaluation Grafana
+
+> **Note** : l'horodatage des alertes (`Dernière évaluation : ...`) n'est disponible qu'après une publication depuis le RPi (`just publish`), car c'est le seul moment où `publish-gh-pages.sh` interroge l'API Grafana. Le format legacy (tableau simple sans timestamp) reste supporté — dans ce cas la date n'est simplement pas affichée.
+
 - **Drag-to-zoom** : sélection au clic-glissé sur les graphiques pour zoomer sur une plage temporelle (style Grafana). Les deux charts se synchronisent automatiquement. Double-clic pour revenir à la vue 48 h live
 - **Sélecteur de plage temporelle** (style Grafana) : clic sur la plage affichée ouvre un panneau avec calendrier, entrées From/To absolues, présets relatifs (5 min → 30 jours), et historique des plages récentes
 

--- a/gh-pages/app.js
+++ b/gh-pages/app.js
@@ -686,5 +686,240 @@
   document.getElementById('bwChart').addEventListener('dblclick', resetToLive);
   document.getElementById('piChart').addEventListener('dblclick', resetToLive);
 
+  // ── Grafana-style time range picker ────────────────────────
+  (() => {
+    const picker = document.getElementById('trPicker');
+    const btn = document.getElementById('rangeLabelBtn');
+    const calEl = document.getElementById('trCal');
+    const fromIn = document.getElementById('trFrom');
+    const toIn = document.getElementById('trTo');
+    const recentSec = document.getElementById('trRecentSec');
+    const recentEl = document.getElementById('trRecent');
+    const relEl = document.getElementById('trRel');
+
+    let pickerOpen = false;
+    let calYear, calMonth; // currently displayed month
+    const dataStart = ts[0];
+
+    // Relative presets (label, hours)
+    const relPresets = [
+      ['5 min', 5 / 60],
+      ['15 min', 0.25],
+      ['30 min', 0.5],
+      ['1 heure', 1],
+      ['3 heures', 3],
+      ['6 heures', 6],
+      ['12 heures', 12],
+      ['24 heures', 24],
+      ['2 jours', 48],
+      ['7 jours', 168],
+      ['30 jours', 720],
+    ];
+
+    // Recent ranges (stored in memory, max 5)
+    let recentRanges = [];
+    const addRecent = (s, e) => {
+      const key = `${s}|${e}`;
+      recentRanges = recentRanges.filter((r) => `${r[0]}|${r[1]}` !== key);
+      recentRanges.unshift([s, e]);
+      if (recentRanges.length > 5) recentRanges.length = 5;
+      renderRecent();
+    };
+
+    // ── Toggle ──
+    const togglePicker = () => {
+      pickerOpen = !pickerOpen;
+      picker.style.display = pickerOpen ? '' : 'none';
+      btn.classList.toggle('open', pickerOpen);
+      if (pickerOpen) syncPickerToRange();
+    };
+    btn.addEventListener('click', togglePicker);
+
+    // Close on outside click
+    document.addEventListener('click', (e) => {
+      if (pickerOpen && !picker.contains(e.target) && !btn.contains(e.target)) {
+        pickerOpen = false;
+        picker.style.display = 'none';
+        btn.classList.remove('open');
+      }
+    });
+
+    // ── Sync picker inputs to current range ──
+    const toLocalISO = (t) => {
+      const d = new Date(t);
+      const off = d.getTimezoneOffset();
+      const local = new Date(d.getTime() - off * 60000);
+      return local.toISOString().slice(0, 16);
+    };
+    const syncPickerToRange = () => {
+      fromIn.value = toLocalISO(rangeStart);
+      toIn.value = toLocalISO(rangeEnd);
+      const d = new Date(rangeStart);
+      calYear = d.getFullYear();
+      calMonth = d.getMonth();
+      renderCal();
+      renderRelActive();
+    };
+
+    // ── Apply absolute range ──
+    const applyAbsolute = () => {
+      const s = new Date(fromIn.value).getTime();
+      const e = new Date(toIn.value).getTime();
+      if (!s || !e || s >= e) return;
+      rangeStart = s;
+      rangeEnd = e;
+      currentH = (rangeEnd - rangeStart) / HOUR;
+      isLive = rangeEnd >= dataEnd;
+      addRecent(s, e);
+      render();
+      togglePicker();
+    };
+    document.getElementById('trApply').addEventListener('click', applyAbsolute);
+
+    // ── Relative presets ──
+    relPresets.forEach(([label, h]) => {
+      const b = document.createElement('button');
+      b.textContent = label;
+      b.dataset.hours = h;
+      b.addEventListener('click', () => {
+        isLive = true;
+        currentH = h;
+        rangeEnd = dataEnd + 600_000;
+        rangeStart = rangeEnd - currentH * HOUR;
+        render();
+        togglePicker();
+      });
+      relEl.appendChild(b);
+    });
+    const renderRelActive = () => {
+      relEl.querySelectorAll('button').forEach((b) => {
+        const h = parseFloat(b.dataset.hours);
+        b.classList.toggle('active', Math.abs(h - currentH) < 0.01 && isLive);
+      });
+    };
+
+    // ── Calendar ──
+    const DAYS = ['Lu', 'Ma', 'Me', 'Je', 'Ve', 'Sa', 'Di'];
+    const MONTHS = [
+      'Janvier',
+      'F\u00e9vrier',
+      'Mars',
+      'Avril',
+      'Mai',
+      'Juin',
+      'Juillet',
+      'Ao\u00fbt',
+      'Septembre',
+      'Octobre',
+      'Novembre',
+      'D\u00e9cembre',
+    ];
+    const renderCal = () => {
+      const first = new Date(calYear, calMonth, 1);
+      const startDay = (first.getDay() + 6) % 7; // Mon=0
+      const daysInMonth = new Date(calYear, calMonth + 1, 0).getDate();
+      const prevDays = new Date(calYear, calMonth, 0).getDate();
+      const today = new Date();
+      const todayStr = `${today.getFullYear()}-${today.getMonth()}-${today.getDate()}`;
+
+      let html = `<div class="tr-cal-hd">
+        <button id="trCalPrev">&lsaquo;</button>
+        <span>${MONTHS[calMonth]} ${calYear}</span>
+        <button id="trCalNext">&rsaquo;</button>
+      </div><table><tr>${DAYS.map((d) => `<th>${d}</th>`).join('')}</tr><tr>`;
+
+      let cell = 0;
+      // Previous month padding
+      for (let i = startDay - 1; i >= 0; i--) {
+        const day = prevDays - i;
+        html += `<td><button class="other" data-date="${calYear}-${calMonth - 1}-${day}">${day}</button></td>`;
+        cell++;
+      }
+      // Current month
+      for (let d = 1; d <= daysInMonth; d++) {
+        if (cell && cell % 7 === 0) html += '</tr><tr>';
+        const dt = new Date(calYear, calMonth, d);
+        const dayStart = dt.getTime();
+        const dayEnd = dayStart + 86400000;
+        const str = `${calYear}-${calMonth}-${d}`;
+        const cls = [];
+        if (str === todayStr) cls.push('today');
+        if (dayEnd < dataStart || dayStart > dataEnd + 600_000) cls.push('no-data');
+        else {
+          if (dayStart >= rangeStart && dayEnd <= rangeEnd) cls.push('in-range');
+          if (
+            (dayStart <= rangeStart && dayEnd > rangeStart) ||
+            (dayStart < rangeEnd && dayEnd >= rangeEnd)
+          )
+            cls.push('sel');
+        }
+        html += `<td><button class="${cls.join(' ')}" data-ts="${dayStart}">${d}</button></td>`;
+        cell++;
+      }
+      // Next month padding
+      let nd = 1;
+      while (cell % 7 !== 0) {
+        html += `<td><button class="other">${nd++}</button></td>`;
+        cell++;
+      }
+      html += '</tr></table>';
+      calEl.innerHTML = html;
+
+      // Calendar nav
+      document.getElementById('trCalPrev').addEventListener('click', () => {
+        calMonth--;
+        if (calMonth < 0) {
+          calMonth = 11;
+          calYear--;
+        }
+        renderCal();
+      });
+      document.getElementById('trCalNext').addEventListener('click', () => {
+        calMonth++;
+        if (calMonth > 11) {
+          calMonth = 0;
+          calYear++;
+        }
+        renderCal();
+      });
+
+      // Day click → set From input to start of day
+      calEl.querySelectorAll('td button[data-ts]').forEach((b) => {
+        if (b.classList.contains('no-data')) return;
+        b.addEventListener('click', () => {
+          const t = parseInt(b.dataset.ts);
+          fromIn.value = toLocalISO(t);
+          toIn.value = toLocalISO(t + 86400000);
+          renderCal();
+        });
+      });
+    };
+
+    // ── Recent ranges ──
+    const renderRecent = () => {
+      if (!recentRanges.length) {
+        recentSec.style.display = 'none';
+        return;
+      }
+      recentSec.style.display = '';
+      recentEl.innerHTML = recentRanges
+        .map(
+          ([s, e]) =>
+            `<button data-s="${s}" data-e="${e}">${fmtDate(s)} \u2192 ${fmtDate(e)}</button>`,
+        )
+        .join('');
+      recentEl.querySelectorAll('button').forEach((b) =>
+        b.addEventListener('click', () => {
+          rangeStart = parseInt(b.dataset.s);
+          rangeEnd = parseInt(b.dataset.e);
+          currentH = (rangeEnd - rangeStart) / HOUR;
+          isLive = rangeEnd >= dataEnd;
+          render();
+          togglePicker();
+        }),
+      );
+    };
+  })();
+
   doRender();
 })();

--- a/gh-pages/app.js
+++ b/gh-pages/app.js
@@ -261,6 +261,27 @@
     cornerRadius: 4,
   };
 
+  // ── Drag-to-zoom (chartjs-plugin-zoom) ─────────────────────
+  const zoomOpts = {
+    zoom: {
+      drag: {
+        enabled: true,
+        backgroundColor: 'rgba(127,127,127,0.15)',
+        borderColor: 'rgba(127,127,127,0.4)',
+        borderWidth: 1,
+      },
+      mode: 'x',
+      onZoomComplete: ({ chart }) => {
+        const { min, max } = chart.scales.x;
+        rangeStart = min;
+        rangeEnd = max;
+        currentH = (rangeEnd - rangeStart) / HOUR;
+        isLive = rangeEnd >= dataEnd;
+        render();
+      },
+    },
+  };
+
   // Charts created once, datasets swapped per mode
   const bwCtx = document.getElementById('bwChart').getContext('2d');
   const bwH = document.getElementById('bwChart').parentElement.clientHeight || 300;
@@ -282,6 +303,7 @@
       },
       plugins: {
         legend: { display: false },
+        zoom: zoomOpts,
         tooltip: {
           ...tipStyle,
           callbacks: {
@@ -317,6 +339,7 @@
       },
       plugins: {
         legend: { display: false },
+        zoom: zoomOpts,
         tooltip: {
           ...tipStyle,
           callbacks: {
@@ -458,6 +481,10 @@
       const [i0, i1] = rng;
       const n = i1 - i0;
 
+      // Padded range: include one sample before/after for continuous curves
+      const p0 = Math.max(0, i0 - 1);
+      const p1 = Math.min(LEN, i1 + 1);
+
       // ── Stats ──────────────────────────────────────────────
       let dlS = 0,
         ulS = 0,
@@ -545,12 +572,12 @@
       document.getElementById('piLeg').innerHTML = `
         <span><i style="background:${COL.pi}"></i>latency${bandLabel}</span>`;
 
-      // ── Datasets ───────────────────────────────────────────
+      // ── Datasets (padded range for edge continuity) ────────
       if (mode === 'band') {
         const bMs = bucketSize();
-        const dlB = bucketize(ts, dl, i0, i1, bMs);
-        const ulB = bucketize(ts, ul, i0, i1, bMs);
-        const piB = bucketize(ts, pi, i0, i1, bMs);
+        const dlB = bucketize(ts, dl, p0, p1, bMs);
+        const ulB = bucketize(ts, ul, p0, p1, bMs);
+        const piB = bucketize(ts, pi, p0, p1, bMs);
 
         bwChart.data.datasets = [
           ...makeBandDs(dlB, COL.dl, 'download'),
@@ -562,8 +589,8 @@
         piChart.options.plugins.tooltip = bandTooltipPi;
       } else {
         bwChart.data.datasets = [
-          ...makeLineDs(ts, dl, i0, i1, COL.dl, 'download', bwCtx, bwH),
-          ...makeLineDs(ts, ul, i0, i1, COL.ul, 'upload', bwCtx, bwH),
+          ...makeLineDs(ts, dl, p0, p1, COL.dl, 'download', bwCtx, bwH),
+          ...makeLineDs(ts, ul, p0, p1, COL.ul, 'upload', bwCtx, bwH),
         ];
         bwChart.options.plugins.tooltip = {
           ...tipStyle,
@@ -572,7 +599,7 @@
           },
         };
 
-        piChart.data.datasets = makeLineDs(ts, pi, i0, i1, COL.pi, 'latency', piCtx, piH);
+        piChart.data.datasets = makeLineDs(ts, pi, p0, p1, COL.pi, 'latency', piCtx, piH);
         piChart.options.plugins.tooltip = {
           ...tipStyle,
           callbacks: {
@@ -650,6 +677,14 @@
     else if (e.key === '+' || e.key === '=') document.getElementById('btnZoomIn').click();
     else if (e.key === '-') document.getElementById('btnZoomOut').click();
   });
+
+  // Double-click on chart → reset to default 48 h live view
+  const resetToLive = () => {
+    isLive = true;
+    setRange(48);
+  };
+  document.getElementById('bwChart').addEventListener('dblclick', resetToLive);
+  document.getElementById('piChart').addEventListener('dblclick', resetToLive);
 
   doRender();
 })();

--- a/gh-pages/app.js
+++ b/gh-pages/app.js
@@ -261,7 +261,15 @@
     cornerRadius: 4,
   };
 
-  // ── Drag-to-zoom (chartjs-plugin-zoom) ─────────────────────
+  // ── Drag-to-zoom (chartjs-plugin-zoom) ──────────────────────
+  const onZoomOrPan = ({ chart }) => {
+    const { min, max } = chart.scales.x;
+    rangeStart = min;
+    rangeEnd = max;
+    currentH = (rangeEnd - rangeStart) / HOUR;
+    isLive = rangeEnd >= dataEnd;
+    render();
+  };
   const zoomOpts = {
     zoom: {
       drag: {
@@ -271,14 +279,7 @@
         borderWidth: 1,
       },
       mode: 'x',
-      onZoomComplete: ({ chart }) => {
-        const { min, max } = chart.scales.x;
-        rangeStart = min;
-        rangeEnd = max;
-        currentH = (rangeEnd - rangeStart) / HOUR;
-        isLive = rangeEnd >= dataEnd;
-        render();
-      },
+      onZoomComplete: onZoomOrPan,
     },
   };
 
@@ -685,6 +686,47 @@
   };
   document.getElementById('bwChart').addEventListener('dblclick', resetToLive);
   document.getElementById('piChart').addEventListener('dblclick', resetToLive);
+
+  // ── Middle-click drag to pan ───────────────────────────────
+  ['bwChart', 'piChart'].forEach((id) => {
+    const canvas = document.getElementById(id);
+    let panning = false,
+      startX = 0,
+      startRange = 0;
+    canvas.addEventListener('mousedown', (e) => {
+      if (e.button !== 1) return; // middle button only
+      e.preventDefault();
+      panning = true;
+      startX = e.clientX;
+      startRange = rangeStart;
+      canvas.style.cursor = 'grabbing';
+    });
+    window.addEventListener('mousemove', (e) => {
+      if (!panning) return;
+      const chart = Chart.getChart(id);
+      const xScale = chart.scales.x;
+      const pxRange = xScale.right - xScale.left;
+      const msPerPx = (rangeEnd - rangeStart) / pxRange;
+      const dx = startX - e.clientX; // drag left → move range forward
+      const shift = dx * msPerPx;
+      rangeStart = startRange + shift;
+      rangeEnd = rangeStart + currentH * HOUR;
+      isLive = rangeEnd >= dataEnd;
+      render();
+    });
+    const stopPan = () => {
+      if (!panning) return;
+      panning = false;
+      canvas.style.cursor = 'crosshair';
+    };
+    window.addEventListener('mouseup', (e) => {
+      if (e.button === 1) stopPan();
+    });
+    // Prevent default middle-click scroll behavior
+    canvas.addEventListener('auxclick', (e) => {
+      if (e.button === 1) e.preventDefault();
+    });
+  });
 
   // ── Grafana-style time range picker ────────────────────────
   (() => {

--- a/gh-pages/app.js
+++ b/gh-pages/app.js
@@ -699,6 +699,8 @@
 
     let pickerOpen = false;
     let calYear, calMonth; // currently displayed month
+    let selFrom = null,
+      selTo = null; // calendar selection state (timestamps)
     const dataStart = ts[0];
 
     // Relative presets (label, hours)
@@ -752,6 +754,8 @@
       return local.toISOString().slice(0, 16);
     };
     const syncPickerToRange = () => {
+      selFrom = rangeStart;
+      selTo = rangeEnd;
       fromIn.value = toLocalISO(rangeStart);
       toIn.value = toLocalISO(rangeEnd);
       const d = new Date(rangeStart);
@@ -775,6 +779,20 @@
       togglePicker();
     };
     document.getElementById('trApply').addEventListener('click', applyAbsolute);
+
+    // Sync calendar highlight when inputs change manually
+    fromIn.addEventListener('change', () => {
+      const t = new Date(fromIn.value).getTime();
+      if (t) selFrom = t;
+      if (toIn.value) selTo = new Date(toIn.value).getTime();
+      renderCal();
+    });
+    toIn.addEventListener('change', () => {
+      if (fromIn.value) selFrom = new Date(fromIn.value).getTime();
+      const t = new Date(toIn.value).getTime();
+      if (t) selTo = t;
+      renderCal();
+    });
 
     // ── Relative presets ──
     relPresets.forEach(([label, h]) => {
@@ -822,6 +840,10 @@
       const today = new Date();
       const todayStr = `${today.getFullYear()}-${today.getMonth()}-${today.getDate()}`;
 
+      // Use picker selection (from inputs) for calendar highlighting
+      const hFrom = selFrom || 0;
+      const hTo = selTo || 0;
+
       let html = `<div class="tr-cal-hd">
         <button id="trCalPrev">&lsaquo;</button>
         <span>${MONTHS[calMonth]} ${calYear}</span>
@@ -832,7 +854,7 @@
       // Previous month padding
       for (let i = startDay - 1; i >= 0; i--) {
         const day = prevDays - i;
-        html += `<td><button class="other" data-date="${calYear}-${calMonth - 1}-${day}">${day}</button></td>`;
+        html += `<td><button class="other">${day}</button></td>`;
         cell++;
       }
       // Current month
@@ -845,13 +867,12 @@
         const cls = [];
         if (str === todayStr) cls.push('today');
         if (dayEnd < dataStart || dayStart > dataEnd + 600_000) cls.push('no-data');
-        else {
-          if (dayStart >= rangeStart && dayEnd <= rangeEnd) cls.push('in-range');
-          if (
-            (dayStart <= rangeStart && dayEnd > rangeStart) ||
-            (dayStart < rangeEnd && dayEnd >= rangeEnd)
-          )
-            cls.push('sel');
+        else if (hFrom && hTo) {
+          // Highlight based on picker From/To selection
+          const rS = Math.min(hFrom, hTo);
+          const rE = Math.max(hFrom, hTo);
+          if (dayStart >= rS && dayEnd <= rE) cls.push('in-range');
+          if ((dayStart <= rS && dayEnd > rS) || (dayStart < rE && dayEnd >= rE)) cls.push('sel');
         }
         html += `<td><button class="${cls.join(' ')}" data-ts="${dayStart}">${d}</button></td>`;
         cell++;
@@ -866,7 +887,8 @@
       calEl.innerHTML = html;
 
       // Calendar nav
-      document.getElementById('trCalPrev').addEventListener('click', () => {
+      document.getElementById('trCalPrev').addEventListener('click', (e) => {
+        e.stopPropagation();
         calMonth--;
         if (calMonth < 0) {
           calMonth = 11;
@@ -874,7 +896,8 @@
         }
         renderCal();
       });
-      document.getElementById('trCalNext').addEventListener('click', () => {
+      document.getElementById('trCalNext').addEventListener('click', (e) => {
+        e.stopPropagation();
         calMonth++;
         if (calMonth > 11) {
           calMonth = 0;
@@ -883,13 +906,27 @@
         renderCal();
       });
 
-      // Day click → set From input to start of day
+      // Day click: first click → set From, second click → set To
       calEl.querySelectorAll('td button[data-ts]').forEach((b) => {
         if (b.classList.contains('no-data')) return;
-        b.addEventListener('click', () => {
+        b.addEventListener('click', (e) => {
+          e.stopPropagation();
           const t = parseInt(b.dataset.ts);
-          fromIn.value = toLocalISO(t);
-          toIn.value = toLocalISO(t + 86400000);
+          if (!selFrom || selTo) {
+            // First click or reset: set From
+            selFrom = t;
+            selTo = null;
+            fromIn.value = toLocalISO(t);
+            toIn.value = '';
+          } else {
+            // Second click: set To (ensure From < To)
+            const a = Math.min(selFrom, t);
+            const z = Math.max(selFrom, t) + 86400000; // end of the later day
+            selFrom = a;
+            selTo = z;
+            fromIn.value = toLocalISO(a);
+            toIn.value = toLocalISO(z);
+          }
           renderCal();
         });
       });

--- a/gh-pages/app.js
+++ b/gh-pages/app.js
@@ -1,23 +1,43 @@
 // ── Alerts ───────────────────────────────────────────────────
 (() => {
-  if (!Array.isArray(ALERTS) || !ALERTS.length) return;
+  // Support both legacy array format and new {alerts, lastEvaluation} format
+  const alertsArr = Array.isArray(ALERTS) ? ALERTS : ALERTS?.alerts;
+  const lastEval = Array.isArray(ALERTS) ? null : ALERTS?.lastEvaluation;
+  if (!Array.isArray(alertsArr) || !alertsArr.length) return;
   document.getElementById('alertsSec').style.display = '';
   // Convert m°C to °C in alert summaries
   const fixTemp = (s) =>
     s ? s.replace(/(\d+)\s*m°C/g, (_, v) => (parseInt(v) / 1000).toFixed(2) + ' °C') : '';
 
-  document.getElementById('alertsList').innerHTML = ALERTS.map((a) => {
-    const icon =
-      a.state === 'firing' ? '\uD83D\uDD34' : a.state === 'pending' ? '\u26A0\uFE0F' : '\u2705';
-    const badge = a.state === 'firing' ? 'firing' : a.state === 'pending' ? 'pending' : 'ok';
-    const label = a.state === 'inactive' ? 'ok' : a.state;
-    return `<div class="al-row">
+  // Format lastEvaluation timestamp
+  const fmtEval = (iso) => {
+    if (!iso) return null;
+    const d = new Date(iso);
+    if (isNaN(d)) return null;
+    const p = (n) => (n < 10 ? '0' + n : '' + n);
+    return `${p(d.getDate())}/${p(d.getMonth() + 1)}/${d.getFullYear()} ${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`;
+  };
+  const evalStr = fmtEval(lastEval);
+  const evalHtml = evalStr
+    ? `<div class="al-eval">Derni\u00e8re \u00e9valuation\u00a0: <time>${evalStr}</time></div>`
+    : '';
+
+  document.getElementById('alertsList').innerHTML =
+    evalHtml +
+    alertsArr
+      .map((a) => {
+        const icon =
+          a.state === 'firing' ? '\uD83D\uDD34' : a.state === 'pending' ? '\u26A0\uFE0F' : '\u2705';
+        const badge = a.state === 'firing' ? 'firing' : a.state === 'pending' ? 'pending' : 'ok';
+        const label = a.state === 'inactive' ? 'ok' : a.state;
+        return `<div class="al-row">
       <span class="al-icon">${icon}</span>
       <span class="al-name">${a.name}</span>
       <span class="al-sum">${fixTemp(a.summary)}</span>
       <span class="al-badge ${badge}">${label}</span>
     </div>`;
-  }).join('');
+      })
+      .join('');
 })();
 
 // ── Charts & Data ────────────────────────────────────────────

--- a/gh-pages/index.template.html
+++ b/gh-pages/index.template.html
@@ -52,7 +52,39 @@
         <button class="nb" id="btnFwd" title="Avancer">&raquo;</button>
         <button class="zb" id="btnZoomOut" title="Zoom −">&minus;</button>
         <button class="zb" id="btnZoomIn" title="Zoom +">+</button>
-        <span class="rl" id="rangeLabel"></span>
+        <button class="rl-btn" id="rangeLabelBtn">
+          <span class="rl" id="rangeLabel"></span>
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <path
+              d="M3 5l3 3 3-3"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
+
+      <!-- Grafana-style time range picker -->
+      <div class="tr-picker" id="trPicker" style="display: none">
+        <div class="tr-left">
+          <div class="tr-section-title">Plage absolue</div>
+          <div class="tr-cal" id="trCal"></div>
+          <div class="tr-abs">
+            <label>De <input type="datetime-local" id="trFrom" step="60" /></label>
+            <label>&Agrave; <input type="datetime-local" id="trTo" step="60" /></label>
+            <button class="tr-apply" id="trApply">Appliquer</button>
+          </div>
+          <div class="tr-recent-section" id="trRecentSec" style="display: none">
+            <div class="tr-section-title">R&eacute;cents</div>
+            <div class="tr-recent" id="trRecent"></div>
+          </div>
+        </div>
+        <div class="tr-right">
+          <div class="tr-section-title">Plages relatives</div>
+          <div class="tr-rel" id="trRel"></div>
+        </div>
       </div>
 
       <div class="panel">

--- a/gh-pages/index.template.html
+++ b/gh-pages/index.template.html
@@ -15,6 +15,8 @@
     <link rel="stylesheet" href="style.css" />
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3"></script>
+    <script src="https://cdn.jsdelivr.net/npm/hammerjs@2"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2"></script>
   </head>
   <body>
     <nav>

--- a/gh-pages/style.css
+++ b/gh-pages/style.css
@@ -296,9 +296,258 @@ nav .meta time {
   font-size: 0.72rem;
   color: var(--text3);
   font-family: 'Geist Mono', monospace;
-  margin-left: 8px;
   min-width: 180px;
   text-align: center;
+}
+.tp .rl-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text2);
+  padding: 4px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-left: 8px;
+  transition: all 0.15s;
+}
+.tp .rl-btn:hover,
+.tp .rl-btn.open {
+  background: var(--surface2);
+  color: var(--text);
+  border-color: var(--border2);
+}
+.tp .rl-btn svg {
+  transition: transform 0.15s;
+}
+.tp .rl-btn.open svg {
+  transform: rotate(180deg);
+}
+
+/* ── TIME RANGE PICKER PANEL ── */
+.tr-picker {
+  position: relative;
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  display: flex;
+  gap: 0;
+  margin-bottom: 12px;
+  overflow: hidden;
+  animation: trSlide 0.15s ease-out;
+}
+@keyframes trSlide {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+.tr-left {
+  flex: 1;
+  padding: 16px;
+  border-right: 1px solid var(--border);
+  min-width: 0;
+}
+.tr-right {
+  width: 180px;
+  padding: 16px;
+  flex-shrink: 0;
+}
+.tr-section-title {
+  font-size: 0.65rem;
+  color: var(--text3);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  margin-bottom: 10px;
+}
+
+/* Calendar */
+.tr-cal {
+  margin-bottom: 14px;
+}
+.tr-cal-hd {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+.tr-cal-hd span {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text);
+}
+.tr-cal-hd button {
+  background: none;
+  border: none;
+  color: var(--text3);
+  cursor: pointer;
+  font-size: 1rem;
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+.tr-cal-hd button:hover {
+  color: var(--text);
+  background: var(--surface2);
+}
+.tr-cal table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: 'Geist Mono', monospace;
+  font-size: 0.68rem;
+}
+.tr-cal th {
+  color: var(--text3);
+  font-weight: 500;
+  padding: 3px;
+  text-align: center;
+  font-size: 0.6rem;
+}
+.tr-cal td {
+  text-align: center;
+  padding: 2px;
+}
+.tr-cal td button {
+  width: 28px;
+  height: 26px;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  color: var(--text2);
+  cursor: pointer;
+  font-family: 'Geist Mono', monospace;
+  font-size: 0.68rem;
+  transition: all 0.1s;
+}
+.tr-cal td button:hover {
+  background: var(--surface2);
+  color: var(--text);
+}
+.tr-cal td button.today {
+  border-color: var(--blue);
+  color: var(--blue);
+}
+.tr-cal td button.in-range {
+  background: rgba(126, 182, 246, 0.12);
+}
+.tr-cal td button.sel {
+  background: var(--blue);
+  color: #fff;
+}
+.tr-cal td button.other {
+  color: var(--text3);
+  opacity: 0.4;
+}
+.tr-cal td button.no-data {
+  color: var(--text3);
+  opacity: 0.2;
+  cursor: default;
+}
+
+/* Absolute inputs */
+.tr-abs {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+  flex-wrap: wrap;
+}
+.tr-abs label {
+  font-size: 0.65rem;
+  color: var(--text3);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.tr-abs input {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-family: 'Geist Mono', monospace;
+  font-size: 0.72rem;
+  padding: 5px 8px;
+  border-radius: 4px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+.tr-abs input:focus {
+  border-color: var(--blue);
+}
+.tr-abs input::-webkit-calendar-picker-indicator {
+  filter: invert(0.6);
+}
+.tr-apply {
+  background: var(--blue);
+  border: none;
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 6px 14px;
+  border-radius: 4px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: opacity 0.15s;
+}
+.tr-apply:hover {
+  opacity: 0.85;
+}
+
+/* Recent ranges */
+.tr-recent-section {
+  margin-top: 14px;
+}
+.tr-recent {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.tr-recent button {
+  background: none;
+  border: none;
+  color: var(--text2);
+  font-family: 'Geist Mono', monospace;
+  font-size: 0.68rem;
+  padding: 4px 6px;
+  border-radius: 3px;
+  cursor: pointer;
+  text-align: left;
+  transition: all 0.1s;
+}
+.tr-recent button:hover {
+  background: var(--surface2);
+  color: var(--text);
+}
+
+/* Relative presets */
+.tr-rel {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.tr-rel button {
+  background: none;
+  border: none;
+  color: var(--text2);
+  font-size: 0.72rem;
+  padding: 5px 8px;
+  border-radius: 3px;
+  cursor: pointer;
+  text-align: left;
+  transition: all 0.1s;
+}
+.tr-rel button:hover {
+  background: var(--surface2);
+  color: var(--text);
+}
+.tr-rel button.active {
+  background: rgba(126, 182, 246, 0.12);
+  color: var(--blue);
 }
 
 /* ── CHART PANELS ── */
@@ -408,6 +657,21 @@ footer a:hover {
   .tp .rl {
     min-width: 130px;
     font-size: 0.66rem;
+  }
+  .tr-picker {
+    flex-direction: column;
+  }
+  .tr-left {
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+  }
+  .tr-right {
+    width: auto;
+  }
+  .tr-rel {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 2px;
   }
   nav .meta {
     font-size: 0.65rem;

--- a/gh-pages/style.css
+++ b/gh-pages/style.css
@@ -181,6 +181,15 @@ nav .meta time {
   margin-bottom: 10px;
   font-weight: 500;
 }
+.al-eval {
+  font-size: 0.68rem;
+  color: var(--text3);
+  font-family: 'Geist Mono', monospace;
+  margin-bottom: 10px;
+}
+.al-eval time {
+  color: var(--blue);
+}
 .al-row {
   display: flex;
   align-items: center;

--- a/gh-pages/style.css
+++ b/gh-pages/style.css
@@ -302,6 +302,10 @@ nav .meta time {
 }
 
 /* ── CHART PANELS ── */
+#bwChart,
+#piChart {
+  cursor: crosshair;
+}
 .panel {
   background: var(--bg2);
   border: 1px solid var(--border);

--- a/scripts/git-pre-commit.sh
+++ b/scripts/git-pre-commit.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Git pre-commit hook: lint & format check on staged files.
+# Only checks files that are actually staged (--cached).
+set -euo pipefail
+
+STAGED=$(git diff --cached --name-only --diff-filter=ACMR)
+if [[ -z "$STAGED" ]]; then
+    exit 0
+fi
+
+FAIL=0
+
+# ── Shell ─────────────────────────────────────────────────
+SH_FILES=$(echo "$STAGED" | grep -E '\.(sh)$' || true)
+if [[ -n "$SH_FILES" ]]; then
+    echo "▶ shellcheck"
+    # shellcheck disable=SC2086
+    shellcheck $SH_FILES || FAIL=1
+    echo "▶ shfmt (check)"
+    # shellcheck disable=SC2086
+    shfmt -d -i 4 -ci $SH_FILES || FAIL=1
+fi
+
+# ── Dockerfile ────────────────────────────────────────────
+DOCKER_FILES=$(echo "$STAGED" | grep -E '(Dockerfile)' || true)
+if [[ -n "$DOCKER_FILES" ]]; then
+    echo "▶ hadolint"
+    # shellcheck disable=SC2086
+    hadolint $DOCKER_FILES || FAIL=1
+fi
+
+# ── YAML ──────────────────────────────────────────────────
+YAML_FILES=$(echo "$STAGED" | grep -E '\.(yml|yaml)$' || true)
+if [[ -n "$YAML_FILES" ]]; then
+    echo "▶ yamllint"
+    # shellcheck disable=SC2086
+    yamllint $YAML_FILES || FAIL=1
+fi
+
+# ── Prettier (HTML, CSS, JS, JSON, MD, YAML, docker-compose) ──
+PR_FILES=$(echo "$STAGED" | grep -E '\.(html|css|js|json|md|yml|yaml)$' || true)
+if [[ -n "$PR_FILES" ]]; then
+    echo "▶ prettier (check)"
+    # shellcheck disable=SC2086
+    npx prettier --check $PR_FILES || FAIL=1
+fi
+
+# ── Python ────────────────────────────────────────────────
+PY_FILES=$(echo "$STAGED" | grep -E '\.py$' || true)
+if [[ -n "$PY_FILES" ]]; then
+    echo "▶ ruff check"
+    # shellcheck disable=SC2086
+    ruff check $PY_FILES || FAIL=1
+    echo "▶ ruff format (check)"
+    # shellcheck disable=SC2086
+    ruff format --check $PY_FILES || FAIL=1
+fi
+
+if [[ "$FAIL" -ne 0 ]]; then
+    echo ""
+    echo "❌ Pre-commit checks failed. Run 'just fmt' to auto-fix formatting."
+    exit 1
+fi
+
+echo "✅ Pre-commit checks passed"

--- a/scripts/git-pre-push.sh
+++ b/scripts/git-pre-push.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Git pre-push hook: run E2E tests before pushing.
+# Requires a preview server on localhost:8080.
+set -euo pipefail
+
+echo "▶ Checking if preview server is running on :8080 ..."
+if ! curl -sf -o /dev/null http://localhost:8080 2>/dev/null; then
+    echo "⚠  No preview server on :8080 — starting one in background ..."
+    just preview-dev 8080 &
+    PREVIEW_PID=$!
+    # Wait for server to be ready (max 30s)
+    for i in $(seq 1 30); do
+        if curl -sf -o /dev/null http://localhost:8080 2>/dev/null; then
+            break
+        fi
+        if [[ "$i" -eq 30 ]]; then
+            echo "❌ Preview server failed to start"
+            kill "$PREVIEW_PID" 2>/dev/null || true
+            exit 1
+        fi
+        sleep 1
+    done
+    trap 'kill $PREVIEW_PID 2>/dev/null || true' EXIT
+fi
+
+echo "▶ Running E2E tests ..."
+just e2e || {
+    echo ""
+    echo "❌ E2E tests failed. Push aborted."
+    exit 1
+}
+
+echo "✅ Pre-push checks passed"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -5,9 +5,13 @@ set -euo pipefail
 
 HOOKS_DIR="$(git rev-parse --show-toplevel)/.git/hooks"
 
-ln -sf "$(pwd)/scripts/git-pre-commit.sh" "$HOOKS_DIR/pre-commit"
+# pre-commit framework handles the pre-commit hook
+pre-commit install
+
+# pre-push: E2E tests (custom script)
 ln -sf "$(pwd)/scripts/git-pre-push.sh" "$HOOKS_DIR/pre-push"
 
+echo ""
 echo "Git hooks installed ✅"
-echo "  pre-commit → lint & format check on staged files"
+echo "  pre-commit → pre-commit framework (lint & format)"
 echo "  pre-push   → E2E tests"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Install git hooks for this repository.
+# Usage: bash scripts/install-hooks.sh
+set -euo pipefail
+
+HOOKS_DIR="$(git rev-parse --show-toplevel)/.git/hooks"
+
+ln -sf "$(pwd)/scripts/git-pre-commit.sh" "$HOOKS_DIR/pre-commit"
+ln -sf "$(pwd)/scripts/git-pre-push.sh" "$HOOKS_DIR/pre-push"
+
+echo "Git hooks installed ✅"
+echo "  pre-commit → lint & format check on staged files"
+echo "  pre-push   → E2E tests"

--- a/scripts/publish-gh-pages.sh
+++ b/scripts/publish-gh-pages.sh
@@ -68,9 +68,13 @@ ALERTS_DATA=$(echo "$ALERTS_JSON" | python3 -c "
 import json, sys
 d = json.load(sys.stdin)
 alerts = []
+last_eval = ''
 for g in d.get('data', {}).get('groups', []):
+    ge = g.get('lastEvaluation', '')
+    if ge > last_eval: last_eval = ge
     for r in g.get('rules', []):
         val = ''
+        re_val = r.get('lastEvaluation', ge)
         for a in r.get('alerts', []):
             s = a.get('annotations', {}).get('summary', '')
             if s: val = s
@@ -79,11 +83,12 @@ for g in d.get('data', {}).get('groups', []):
             'state': r['state'],
             'health': r.get('health', ''),
             'severity': r.get('labels', {}).get('severity', ''),
-            'summary': val
+            'summary': val,
+            'lastEvaluation': re_val
         })
-print(json.dumps(alerts))
+print(json.dumps({'alerts': alerts, 'lastEvaluation': last_eval}))
 ")
-ALERT_COUNT=$(echo "$ALERTS_DATA" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))")
+ALERT_COUNT=$(echo "$ALERTS_DATA" | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d.get('alerts', d) if isinstance(d, dict) else d))")
 echo "  → $ALERT_COUNT alert rules exported"
 
 # ── 2. Build the static page ─────────────────────────────

--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -133,7 +133,36 @@ test('double-click on chart resets to live view', async ({ page }) => {
   await expect(page.locator('.rb[data-hours="48"]')).toHaveClass(/on/, { timeout: 5000 });
 });
 
-// ── 10. Capture screenshot for PR comment ───────────────────
+// ── 10. Time range picker opens and has content ─────────────
+test('time range picker opens with calendar and presets', async ({ page }) => {
+  const picker = page.locator('#trPicker');
+  await expect(picker).toBeHidden();
+
+  // Click the range label button to open
+  await page.click('#rangeLabelBtn');
+  await expect(picker).toBeVisible();
+
+  // Calendar is rendered with day buttons
+  const calDays = picker.locator('.tr-cal td button');
+  expect(await calDays.count()).toBeGreaterThan(20);
+
+  // Relative presets are rendered
+  const relBtns = picker.locator('.tr-rel button');
+  expect(await relBtns.count()).toBeGreaterThanOrEqual(10);
+
+  // Absolute inputs exist
+  await expect(page.locator('#trFrom')).toBeVisible();
+  await expect(page.locator('#trTo')).toBeVisible();
+
+  // Selecting a relative preset closes the picker and updates the view
+  const rangeLabel = page.locator('#rangeLabel');
+  const initialText = await rangeLabel.textContent();
+  await relBtns.filter({ hasText: '6 heures' }).click();
+  await expect(picker).toBeHidden();
+  await expect(rangeLabel).not.toHaveText(initialText, { timeout: 3000 });
+});
+
+// ── 11. Capture screenshot for PR comment ───────────────────
 test('capture preview screenshot', async ({ page }) => {
   // Give charts a moment to finish animating
   await page.waitForTimeout(500);

--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -98,7 +98,42 @@ test('data contains a reasonable number of points', async ({ page }) => {
   expect(count).toBeGreaterThan(100);
 });
 
-// ── 8. Capture screenshot for PR comment ────────────────────
+// ── 8. Drag-to-zoom plugin is loaded and configured ─────────
+test('drag-to-zoom plugin is configured on charts', async ({ page }) => {
+  const config = await page.evaluate(() => {
+    const bw = Chart.getChart('bwChart');
+    const pi = Chart.getChart('piChart');
+    return {
+      bwDrag: bw?.options?.plugins?.zoom?.zoom?.drag?.enabled,
+      piDrag: pi?.options?.plugins?.zoom?.zoom?.drag?.enabled,
+      bwMode: bw?.options?.plugins?.zoom?.zoom?.mode,
+      piMode: pi?.options?.plugins?.zoom?.zoom?.mode,
+      hasZoomFn: typeof bw?.zoom === 'function',
+      hasResetFn: typeof bw?.resetZoom === 'function',
+    };
+  });
+  expect(config.bwDrag).toBe(true);
+  expect(config.piDrag).toBe(true);
+  expect(config.bwMode).toBe('x');
+  expect(config.piMode).toBe('x');
+  expect(config.hasZoomFn).toBe(true);
+  expect(config.hasResetFn).toBe(true);
+});
+
+// ── 9. Double-click on chart resets to default 48 h view ────
+test('double-click on chart resets to live view', async ({ page }) => {
+  // Switch to 6h to change the current range
+  await page.click('.rb[data-hours="6"]');
+  await expect(page.locator('.rb[data-hours="6"]')).toHaveClass(/on/);
+
+  // Double-click on bandwidth chart to reset
+  await page.locator('#bwChart').dblclick();
+
+  // The "2j" (48h) button should be active again
+  await expect(page.locator('.rb[data-hours="48"]')).toHaveClass(/on/, { timeout: 5000 });
+});
+
+// ── 10. Capture screenshot for PR comment ───────────────────
 test('capture preview screenshot', async ({ page }) => {
   // Give charts a moment to finish animating
   await page.waitForTimeout(500);


### PR DESCRIPTION
## Interactions charts style Grafana

### Drag-to-zoom (brush select)
- Clic-glissé gauche sur les graphiques pour zoomer sur une plage temporelle
- Les deux charts (bandwidth + latency) se synchronisent automatiquement
- Datasets paddés ±1 sample pour continuité visuelle aux bords
- Double-clic pour revenir à la vue 48h live
- Curseur crosshair sur les canvas

### Sélecteur de plage temporelle (style Grafana)
- Clic sur la plage affichée ouvre un panneau dropdown
- **Gauche** : calendrier mois (navigation ‹/›), inputs datetime From/To absolus, bouton Appliquer, historique des plages récentes (max 5)
- **Droite** : présets relatifs (5 min → 30 jours)
- Sélection calendrier en 2 clics (From → To) avec surlignage visuel
- Responsive : layout empilé sur mobile

### Middle-click pan
- Clic milieu + glisser sur n'importe quel chart panne la plage temporelle
- Calcul ms/px depuis l'échelle du chart pour un déplacement précis
- Curseur `grabbing` pendant le pan

### Stack technique
- [chartjs-plugin-zoom](https://www.chartjs.org/chartjs-plugin-zoom/) + [Hammer.js](https://hammerjs.github.io/) via CDN
- Custom middle-click pan handler (natif, sans plugin)

### Tests
- 12 tests E2E Playwright (vs 9 sur master)
- Nouveaux tests : config zoom plugin, dblclick reset, picker ouverture/présets
- Tous les linters passent (shellcheck, shfmt, hadolint, yamllint, prettier, ruff)