### PR TITLE
feat: add RPi4 ARM64 simulation stack with e2e smoke tests and nightly CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,10 +24,10 @@ jobs:
           sudo chmod +x /usr/local/bin/shfmt
 
       - name: shellcheck
-        run: shellcheck scripts/*.sh docker-entrypoint.sh test-stack.sh
+        run: shellcheck scripts/*.sh sim/*.sh docker-entrypoint.sh test-stack.sh
 
       - name: shfmt
-        run: shfmt -d -i 4 -ci scripts/*.sh docker-entrypoint.sh test-stack.sh
+        run: shfmt -d -i 4 -ci scripts/*.sh sim/*.sh docker-entrypoint.sh test-stack.sh
 
       - name: hadolint
         run: hadolint Dockerfile

--- a/.github/workflows/sim-e2e-nightly.yml
+++ b/.github/workflows/sim-e2e-nightly.yml
@@ -1,6 +1,8 @@
 name: Sim Stack E2E — Nightly
 
 on:
+  push:
+    branches: [feat/sim-arm64-stack] # TEMP: trigger on push for PR testing — remove before merge
   schedule:
     # Every night at 03:30 UTC (offset from e2e-nightly at 03:00)
     - cron: '30 3 * * *'

--- a/.github/workflows/sim-e2e-nightly.yml
+++ b/.github/workflows/sim-e2e-nightly.yml
@@ -1,0 +1,68 @@
+name: Sim Stack E2E — Nightly
+
+on:
+  schedule:
+    # Every night at 03:30 UTC (offset from e2e-nightly at 03:00)
+    - cron: '30 3 * * *'
+  workflow_dispatch: # Manual trigger for PR validation
+
+jobs:
+  sim-e2e:
+    name: Sim stack smoke tests (ARM64 / QEMU)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Register QEMU binfmt handlers
+        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
+      - name: Build and start sim stack
+        run: |
+          docker compose \
+            -f docker-compose.yml \
+            -f sim/docker-compose.sim.yml \
+            --env-file sim/.env.sim \
+            -p rpi-sim \
+            up -d --build
+
+      - name: Wait for InfluxDB healthy
+        run: |
+          echo "Waiting for InfluxDB healthy (QEMU ~2-3 min)..."
+          timeout 180 bash -c '
+            until docker inspect influxdb \
+              --format "{{.State.Health.Status}}" 2>/dev/null \
+              | grep -q healthy; do
+              sleep 5
+            done
+          '
+          echo "InfluxDB healthy."
+
+      - name: Wait for Telegraf data
+        run: |
+          echo "Waiting for Telegraf to collect data (~90s under QEMU)..."
+          sleep 90
+
+      - name: Run sim smoke tests
+        run: ./scripts/test-sim-stack.sh
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          {
+            docker compose -p rpi-sim logs --no-color 2>&1
+            echo "──────────────────────────────────────"
+            docker compose -p rpi-sim ps --all 2>&1
+          } > sim-logs.txt
+
+      - name: Upload logs artifact
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sim-e2e-logs
+          path: sim-logs.txt
+          retention-days: 7
+
+      - name: Teardown
+        if: always()
+        run: docker compose -p rpi-sim down -v

--- a/.github/workflows/sim-e2e-nightly.yml
+++ b/.github/workflows/sim-e2e-nightly.yml
@@ -1,8 +1,6 @@
 name: Sim Stack E2E — Nightly
 
 on:
-  push:
-    branches: [feat/sim-arm64-stack] # TEMP: trigger on push for PR testing — remove before merge
   schedule:
     # Every night at 03:30 UTC (offset from e2e-nightly at 03:00)
     - cron: '30 3 * * *'

--- a/Justfile
+++ b/Justfile
@@ -198,7 +198,7 @@ cron:
 
 # Lint all source files
 lint:
-    shellcheck scripts/*.sh docker-entrypoint.sh test-stack.sh
+    shellcheck scripts/*.sh sim/*.sh docker-entrypoint.sh test-stack.sh
     hadolint Dockerfile
     yamllint docker-compose.yml .github/workflows/*.yml grafana/provisioning/alerting/alerts.yml .yamllint.yml .hadolint.yaml
     npx prettier --check 'gh-pages/*.{html,css,js}' '**/*.json' '**/*.md' 'docker-compose.yml' '.github/workflows/*.yml'
@@ -282,3 +282,7 @@ sim-stats:
 # Register QEMU user-static (needed once per host reboot)
 sim-binfmt:
     docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
+# Run the sim smoke test suite (25 checks)
+sim-test:
+    ./scripts/test-sim-stack.sh

--- a/Justfile
+++ b/Justfile
@@ -242,7 +242,7 @@ sim-nuke:
 sim-status:
     @{{ sim_compose }} ps -a
     @echo ""
-    @docker inspect rpi-sim-influxdb-1 rpi-sim-grafana-1 rpi-sim-telegraf-1 rpi-sim-chronograf-1 speedtest-cron 2>/dev/null | jq -r '.[] | "  \(.Name | ltrimstr("/")): \(.State.Health.Status // "n/a")"' || true
+    @docker inspect influxdb grafana telegraf chronograf speedtest-cron 2>/dev/null | jq -r '.[] | "  \(.Name | ltrimstr("/")): \(.State.Health.Status // "n/a")"' || true
 
 # Show simulation logs
 sim-logs lines="50":
@@ -262,22 +262,22 @@ sim-speedtest:
 
 # Open an InfluxDB shell in the simulation
 sim-influx-shell:
-    docker exec -it rpi-sim-influxdb-1 influx -username admin -password simpass
+    docker exec -it influxdb influx -username admin -password simpass
 
 # Show simulation stats (databases, counts, disk)
 sim-stats:
     @echo "── Databases ──"
-    @docker exec rpi-sim-influxdb-1 influx -username admin -password simpass -execute "SHOW DATABASES"
+    @docker exec influxdb influx -username admin -password simpass -execute "SHOW DATABASES"
     @echo ""
     @echo "── Retention Policies ──"
     @for db in speedtest telegraf; do \
-        echo "  $$db:"; \
-        docker exec rpi-sim-influxdb-1 influx -username admin -password simpass -execute "SHOW RETENTION POLICIES ON $$db" 2>/dev/null | tail -2; \
+        echo "  $db:"; \
+        docker exec influxdb influx -username admin -password simpass -execute "SHOW RETENTION POLICIES ON $db" 2>/dev/null | tail -2; \
         echo ""; \
     done
     @echo "── Data Counts ──"
-    @printf "  Speedtest points: %s\n" "$$(docker exec rpi-sim-influxdb-1 influx -username admin -password simpass -execute 'SELECT COUNT(download_bandwidth) FROM speedtest' -database speedtest 2>/dev/null | tail -1 | awk '{print $$2}')"
-    @printf "  Telegraf cpu (last 1h): %s\n" "$$(docker exec rpi-sim-influxdb-1 influx -username admin -password simpass -execute 'SELECT COUNT(usage_idle) FROM cpu WHERE time > now() - 1h' -database telegraf 2>/dev/null | tail -1 | awk '{print $$2}')"
+    @printf "  Speedtest points: %s\n" "$(docker exec influxdb influx -username admin -password simpass -execute 'SELECT COUNT(download_bandwidth) FROM speedtest' -database speedtest 2>/dev/null | tail -1 | awk '{print $2}')"
+    @printf "  Telegraf cpu (last 1h): %s\n" "$(docker exec influxdb influx -username admin -password simpass -execute 'SELECT COUNT(usage_idle) FROM cpu WHERE time > now() - 1h' -database telegraf 2>/dev/null | tail -1 | awk '{print $2}')"
 
 # Register QEMU user-static (needed once per host reboot)
 sim-binfmt:

--- a/Justfile
+++ b/Justfile
@@ -208,7 +208,7 @@ lint:
 
 # Auto-format all source files
 fmt:
-    shfmt -w -i 4 -ci scripts/*.sh docker-entrypoint.sh test-stack.sh
+    shfmt -w -i 4 -ci scripts/*.sh sim/*.sh docker-entrypoint.sh test-stack.sh
     npx prettier --write 'gh-pages/*.{html,css,js}' '**/*.json' '**/*.md' 'docker-compose.yml' '.github/workflows/*.yml'
     ruff format scripts/*.py
     @echo "All files formatted ✅"
@@ -242,7 +242,7 @@ sim-nuke:
 sim-status:
     @{{ sim_compose }} ps -a
     @echo ""
-    @docker inspect rpi-sim-influxdb-1 rpi-sim-grafana-1 rpi-sim-telegraf-1 rpi-sim-chronograf-1 2>/dev/null | jq -r '.[] | "  \(.Name | ltrimstr("/")): \(.State.Health.Status // "n/a")"' || true
+    @docker inspect rpi-sim-influxdb-1 rpi-sim-grafana-1 rpi-sim-telegraf-1 rpi-sim-chronograf-1 speedtest-cron 2>/dev/null | jq -r '.[] | "  \(.Name | ltrimstr("/")): \(.State.Health.Status // "n/a")"' || true
 
 # Show simulation logs
 sim-logs lines="50":

--- a/Justfile
+++ b/Justfile
@@ -216,3 +216,69 @@ fmt:
 # E2E tests against a local or remote preview (default: http://localhost:8080)
 e2e url="http://localhost:8080":
     E2E_BASE_URL={{ url }} npx playwright test
+
+# ── RPi4 Simulation (ARM64 on x86) ─────────────────────
+
+sim_compose := "docker compose -f docker-compose.yml -f sim/docker-compose.sim.yml --env-file sim/.env.sim -p rpi-sim"
+
+# Start the RPi4 simulation stack (ARM64 emulated via QEMU)
+sim-up:
+    {{ sim_compose }} up -d
+
+# Stop the simulation stack
+sim-stop:
+    {{ sim_compose }} stop
+
+# Stop and remove simulation containers (preserves volumes)
+sim-down:
+    {{ sim_compose }} down
+
+# Stop, remove containers AND simulation volumes (⚠️ destroys sim data)
+[confirm("⚠️  This will DELETE ALL simulation data. Continue?")]
+sim-nuke:
+    {{ sim_compose }} down -v
+
+# Show simulation container status
+sim-status:
+    @{{ sim_compose }} ps -a
+    @echo ""
+    @docker inspect rpi-sim-influxdb-1 rpi-sim-grafana-1 rpi-sim-telegraf-1 rpi-sim-chronograf-1 2>/dev/null | jq -r '.[] | "  \(.Name | ltrimstr("/")): \(.State.Health.Status // "n/a")"' || true
+
+# Show simulation logs
+sim-logs lines="50":
+    {{ sim_compose }} logs --tail={{ lines }}
+
+# Follow simulation logs in real-time
+sim-logs-follow:
+    {{ sim_compose }} logs -f --tail=20
+
+# Build the speedtest image for ARM64
+sim-build:
+    {{ sim_compose }} build speedtest
+
+# Run a manual speedtest in the simulation
+sim-speedtest:
+    {{ sim_compose }} run --rm speedtest
+
+# Open an InfluxDB shell in the simulation
+sim-influx-shell:
+    docker exec -it rpi-sim-influxdb-1 influx -username admin -password simpass
+
+# Show simulation stats (databases, counts, disk)
+sim-stats:
+    @echo "── Databases ──"
+    @docker exec rpi-sim-influxdb-1 influx -username admin -password simpass -execute "SHOW DATABASES"
+    @echo ""
+    @echo "── Retention Policies ──"
+    @for db in speedtest telegraf; do \
+        echo "  $$db:"; \
+        docker exec rpi-sim-influxdb-1 influx -username admin -password simpass -execute "SHOW RETENTION POLICIES ON $$db" 2>/dev/null | tail -2; \
+        echo ""; \
+    done
+    @echo "── Data Counts ──"
+    @printf "  Speedtest points: %s\n" "$$(docker exec rpi-sim-influxdb-1 influx -username admin -password simpass -execute 'SELECT COUNT(download_bandwidth) FROM speedtest' -database speedtest 2>/dev/null | tail -1 | awk '{print $$2}')"
+    @printf "  Telegraf cpu (last 1h): %s\n" "$$(docker exec rpi-sim-influxdb-1 influx -username admin -password simpass -execute 'SELECT COUNT(usage_idle) FROM cpu WHERE time > now() - 1h' -database telegraf 2>/dev/null | tail -1 | awk '{print $$2}')"
+
+# Register QEMU user-static (needed once per host reboot)
+sim-binfmt:
+    docker run --rm --privileged multiarch/qemu-user-static --reset -p yes

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ just install-timers
 | `just test`      | **oui**    | Suite de régression complète (17 checks)                |
 | `just check`     | **oui**    | Health check rapide des 4 services                      |
 | `just e2e [url]` | non        | Tests E2E Playwright contre une preview (défaut: :8080) |
+| `just sim-test`  | non        | Smoke tests de la stack sim (25 checks)                 |
 | `just lint`      | non        | Vérifier le formatage et le linting de tous les sources |
 | `just fmt`       | non        | Auto-formater tous les fichiers sources                 |
 
@@ -132,6 +133,26 @@ just install-timers
 | `just timer-status`     | État des timers + logs récents                          |
 
 Les timers remplacent le crontab : la configuration est versionnée dans `systemd/`, installée via `just install-timers`, et visible via `systemctl --user list-timers`. Logs consultables avec `journalctl --user -u speedtest` / `-u publish-gh-pages`.
+
+### Simulation RPi4 (ARM64 sur x86)
+
+Stack de simulation locale : tous les containers tournent en ARM64 via QEMU, reproduisant l'architecture du RPi4 de production. Voir [docs/sim-environment.md](docs/sim-environment.md) pour le détail complet.
+
+| Commande             | Description                                         |
+| -------------------- | --------------------------------------------------- |
+| `just sim-binfmt`    | Enregistrer les handlers QEMU (1× par reboot)       |
+| `just sim-up`        | Démarrer la stack sim complète                      |
+| `just sim-stop`      | Arrêter (préserve l'état)                           |
+| `just sim-down`      | Supprimer les containers (préserve les volumes)     |
+| `just sim-nuke`      | Supprimer containers **et** volumes (⚠️ destructif) |
+| `just sim-status`    | État des containers + health checks                 |
+| `just sim-logs`      | Dernières 50 lignes de logs                         |
+| `just sim-build`     | Build l'image speedtest pour ARM64                  |
+| `just sim-speedtest` | Lancer un speedtest manuellement                    |
+| `just sim-test`      | Suite de smoke tests (25 checks)                    |
+| `just sim-stats`     | Bases de données, rétention, compteurs              |
+
+Grafana : <http://localhost:3000> (admin / simpass) — Chronograf : <http://localhost:8888>
 
 ### Utilitaires
 
@@ -316,6 +337,10 @@ just fmt       # Auto-formater tous les fichiers
 | ruff       | Python (lint + format)              |
 
 La CI exécute `just lint` sur chaque push et PR via `.github/workflows/lint.yml`.
+
+#### Sim Stack — Nightly E2E
+
+Un workflow dédié (`.github/workflows/sim-e2e-nightly.yml`) démarre la stack ARM64 complète sur un runner Ubuntu chaque nuit (03:30 UTC) et exécute les 25 smoke tests. Déclenchable manuellement via l'onglet **Actions** → **Sim Stack E2E — Nightly** → **Run workflow** pour valider une PR.
 
 ## GitHub Pages — Vue externe
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Monitoring Débit Internet — RPi4
 
+[![Lint](https://github.com/yoyonel/rpi-internet-monitoring/actions/workflows/lint.yml/badge.svg)](https://github.com/yoyonel/rpi-internet-monitoring/actions/workflows/lint.yml)
+[![E2E Nightly — Production](https://github.com/yoyonel/rpi-internet-monitoring/actions/workflows/e2e-nightly.yml/badge.svg)](https://github.com/yoyonel/rpi-internet-monitoring/actions/workflows/e2e-nightly.yml)
+[![Sim Stack E2E — Nightly](https://github.com/yoyonel/rpi-internet-monitoring/actions/workflows/sim-e2e-nightly.yml/badge.svg)](https://github.com/yoyonel/rpi-internet-monitoring/actions/workflows/sim-e2e-nightly.yml)
+[![Deploy GitHub Pages](https://github.com/yoyonel/rpi-internet-monitoring/actions/workflows/deploy-gh-pages.yml/badge.svg)](https://github.com/yoyonel/rpi-internet-monitoring/actions/workflows/deploy-gh-pages.yml)
+[![GitHub Pages](https://img.shields.io/website?url=https%3A%2F%2Fyoyonel.github.io%2Frpi-internet-monitoring%2F&label=GitHub%20Pages)](https://yoyonel.github.io/rpi-internet-monitoring/)
+
 Stack Docker pour monitorer le débit internet (download, upload, ping) via [Ookla Speedtest CLI](https://www.speedtest.net/apps/cli), avec stockage dans InfluxDB et visualisation dans Grafana.
 
 ## Architecture

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,14 @@ services:
     environment:
       GF_SECURITY_ADMIN_USER: ${GF_SECURITY_ADMIN_USER}
       GF_SECURITY_ADMIN_PASSWORD: ${GF_SECURITY_ADMIN_PASSWORD}
+      INFLUXDB_USER: ${INFLUXDB_USER}
+      INFLUXDB_USER_PASSWORD: ${INFLUXDB_USER_PASSWORD}
     volumes:
       - grafana-storage:/var/lib/grafana
       - ./grafana/provisioning/alerting:/etc/grafana/provisioning/alerting:ro
+      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
+      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
     networks:
       - speedtest
     ports:

--- a/docs/sim-environment.md
+++ b/docs/sim-environment.md
@@ -1,0 +1,178 @@
+# Simulation Environment (ARM64 on x86)
+
+Run the full RPi4 monitoring stack locally on an x86_64 host using QEMU
+user-mode emulation. Every container runs as `linux/arm64` — the same
+architecture as the production Raspberry Pi — so images, configs and
+dashboards are tested in near-production conditions.
+
+## Prerequisites
+
+| Tool             | Version tested | Notes               |
+| ---------------- | -------------- | ------------------- |
+| Docker           | 25.9+          | Compose V2 built-in |
+| QEMU user-static | latest         | ARM64 emulation     |
+
+Register the QEMU binfmt handlers (once per host reboot):
+
+```bash
+just sim-binfmt
+# or: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+```
+
+## Quick start
+
+```bash
+just sim-up        # start the whole stack
+just sim-status    # check container health
+just sim-logs      # last 50 lines of logs
+```
+
+Grafana: <http://localhost:3000> (admin / simpass)
+Chronograf: <http://localhost:8888>
+InfluxDB API: <http://localhost:8086> (admin / simpass)
+
+## Architecture
+
+```
+sim/.env.sim                  ← credentials (safe local defaults)
+sim/docker-compose.sim.yml    ← ARM64 override layer
+sim/telegraf-sim.conf         ← Telegraf config adapted for x86 host
+docker-compose.yml            ← base compose (shared with production)
+```
+
+The simulation uses Docker Compose's override mechanism:
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f sim/docker-compose.sim.yml \
+  --env-file sim/.env.sim \
+  -p rpi-sim \
+  up -d
+```
+
+The `-p rpi-sim` project name isolates containers and volumes from any
+production deployment on the same host.
+
+### What the sim overlay changes
+
+| Service      | Override                                                  | Why                                                                               |
+| ------------ | --------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| All services | `platform: linux/arm64`                                   | Force ARM64 emulation via QEMU                                                    |
+| All services | `mem_limit` / `memswap_limit`                             | Simulate RPi4 4 GB memory budget                                                  |
+| influxdb     | `cap_add: CHOWN, DAC_OVERRIDE, SETUID, SETGID, FOWNER`    | Entrypoint needs these to init data dir (base compose has `cap_drop: ALL`)        |
+| influxdb     | Healthcheck: `timeout 30s, retries 10, start_period 120s` | QEMU emulation is ~10× slower than native                                         |
+| influxdb     | `ports: 127.0.0.1:8086:8086`                              | Expose for external tooling                                                       |
+| influxdb     | `INFLUXDB_MONITOR_STORE_ENABLED: false`                   | Skip `_internal` database to save resources                                       |
+| telegraf     | `hostname: rpi-sim`, custom `telegraf-sim.conf`           | x86-compatible inputs (thermal_zone0 instead of BCM2711, wildcard net interfaces) |
+| speedtest    | `platform: linux/arm64` + ARM64 build                     | Build the speedtest image for ARM64                                               |
+
+### Memory budget (RPi4 — 4 GB)
+
+| Service             | mem_limit   | memswap_limit |
+| ------------------- | ----------- | ------------- |
+| Grafana             | 512 MB      | 768 MB        |
+| InfluxDB            | 1 GB        | 1.5 GB        |
+| Telegraf            | 256 MB      | 384 MB        |
+| Chronograf          | 256 MB      | 384 MB        |
+| docker-socket-proxy | 64 MB       | 64 MB         |
+| **Total**           | **~2.1 GB** | **~3.1 GB**   |
+
+## Grafana provisioning
+
+Datasources and dashboards are provisioned as code — no manual UI setup
+required.
+
+### Datasources (`grafana/provisioning/datasources/influxdb.yml`)
+
+| Name               | UID                  | Database    | Default |
+| ------------------ | -------------------- | ----------- | ------- |
+| InfluxDB           | `2QPKy_O4k`          | `telegraf`  | Yes     |
+| InfluxDB-Speedtest | `influxdb-speedtest` | `speedtest` | No      |
+
+Credentials are injected via environment variables (`INFLUXDB_USER` /
+`INFLUXDB_USER_PASSWORD`), set in `sim/.env.sim` for simulation or in
+production `.env`.
+
+### Dashboards (`grafana/provisioning/dashboards/dashboards.yml`)
+
+A file provider watches `/var/lib/grafana/dashboards` (mounted from
+`grafana/dashboards/`) and auto-reloads every 30 seconds.
+
+| Dashboard           | File                     | Datasource                     |
+| ------------------- | ------------------------ | ------------------------------ |
+| Docker Containers   | `docker-containers.json` | InfluxDB (telegraf)            |
+| RPi Alerts Overview | `rpi-alerts.json`        | InfluxDB (telegraf)            |
+| Internet Speedtest  | `speedtest.json`         | InfluxDB-Speedtest (speedtest) |
+| System Metrics      | `system-metrics.json`    | InfluxDB (telegraf)            |
+
+Dashboard JSON files are in **raw format** (not wrapped in
+`{"dashboard": {...}}` like Grafana API exports). The original export
+files are preserved in `speedtest/dashboard.json` and
+`telegraf/dashboard.json`.
+
+## Telegraf sim config
+
+`sim/telegraf-sim.conf` collects the same metrics as production but with
+x86-compatible inputs:
+
+- **CPU temperature**: reads `/sys/class/thermal/thermal_zone0/temp`
+  (x86) instead of BCM2711 thermal sensor — produces the same
+  `cpu_temperature` measurement
+- **Network interfaces**: wildcard (auto-detect) instead of hardcoded
+  `eth0` / `wlan0`
+- **Docker**: same socket-proxy pattern as production
+- **Tag**: `env = "sim"` to distinguish sim data from production
+
+## Justfile recipes
+
+| Recipe             | Description                                               |
+| ------------------ | --------------------------------------------------------- |
+| `sim-up`           | Start the full simulation stack                           |
+| `sim-stop`         | Stop containers (preserve state)                          |
+| `sim-down`         | Stop and remove containers (preserve volumes)             |
+| `sim-nuke`         | Stop, remove containers AND volumes (confirmation prompt) |
+| `sim-status`       | Container status + health checks                          |
+| `sim-logs [lines]` | Show last N lines (default 50)                            |
+| `sim-logs-follow`  | Follow logs in real-time                                  |
+| `sim-build`        | Build the speedtest image for ARM64                       |
+| `sim-speedtest`    | Run a manual speedtest                                    |
+| `sim-influx-shell` | Open InfluxDB CLI in the sim container                    |
+| `sim-stats`        | Show databases, retention policies, data counts           |
+| `sim-binfmt`       | Register QEMU binfmt handlers                             |
+
+## Troubleshooting
+
+### InfluxDB fails to start (permission denied)
+
+The base compose uses `cap_drop: ALL`. The InfluxDB 1.8 entrypoint
+runs `mkdir` / `chown` on its data directory. The sim overlay adds
+back the minimum capabilities needed (`CHOWN`, `DAC_OVERRIDE`, `SETUID`,
+`SETGID`, `FOWNER`).
+
+### InfluxDB healthcheck timeout under QEMU
+
+ARM64 emulation on x86 is ~10× slower. The sim overlay increases
+`start_period` to 120s and `retries` to 10. First startup can take
+2-3 minutes.
+
+### Empty dashboards after first boot
+
+InfluxDB auto-creates the `telegraf` and `speedtest` databases on
+first start, but the `telegraf` user may lack privileges. If dashboards
+show no data, grant access:
+
+```bash
+just sim-influx-shell
+> GRANT ALL ON telegraf TO telegraf
+> GRANT ALL ON speedtest TO telegraf
+```
+
+### Running a speedtest
+
+The `speedtest` service uses `profiles: [run-once]` — it does not start
+with `docker compose up`. Trigger it manually:
+
+```bash
+just sim-speedtest
+```

--- a/docs/sim-environment.md
+++ b/docs/sim-environment.md
@@ -143,6 +143,7 @@ x86-compatible inputs:
 | `sim-speedtest`    | Run a manual speedtest                                    |
 | `sim-influx-shell` | Open InfluxDB CLI in the sim container                    |
 | `sim-stats`        | Show databases, retention policies, data counts           |
+| `sim-test`         | Run the smoke test suite (25 checks, 7 sections)          |
 | `sim-binfmt`       | Register QEMU binfmt handlers                             |
 
 ## Simulation fidelity vs production RPi

--- a/docs/sim-environment.md
+++ b/docs/sim-environment.md
@@ -37,6 +37,7 @@ InfluxDB API: <http://localhost:8086> (admin / simpass)
 sim/.env.sim                  ← credentials (safe local defaults)
 sim/docker-compose.sim.yml    ← ARM64 override layer
 sim/telegraf-sim.conf         ← Telegraf config adapted for x86 host
+sim/speedtest-loop.sh         ← periodic speedtest loop (replaces systemd timer)
 docker-compose.yml            ← base compose (shared with production)
 ```
 
@@ -76,7 +77,8 @@ production deployment on the same host.
 | Telegraf            | 256 MB      | 384 MB        |
 | Chronograf          | 256 MB      | 384 MB        |
 | docker-socket-proxy | 64 MB       | 64 MB         |
-| **Total**           | **~2.1 GB** | **~3.1 GB**   |
+| speedtest-cron      | 256 MB      | 384 MB        |
+| **Total**           | **~2.3 GB** | **~3.5 GB**   |
 
 ## Grafana provisioning
 
@@ -174,7 +176,7 @@ x86-compatible inputs:
 | **Global tag**                 | `env = "sim"` (in telegraf-sim.conf)                     | No env tag (production telegraf.conf)                | Easy to distinguish in InfluxDB queries                    |
 | **InfluxDB capabilities**      | `cap_add` for CHOWN/DAC_OVERRIDE/etc.                    | `cap_drop: ALL` only                                 | Sim is slightly more permissive (required for QEMU init)   |
 | **Credentials**                | Hardcoded `simpass` in `.env.sim`                        | Real secrets in production `.env` (not in repo)      | No security concern — sim is local-only                    |
-| **systemd timers**             | Not present (speedtest triggered manually)               | `speedtest.timer` + `publish-gh-pages.timer`         | Scheduling pipeline not tested in sim                      |
+| **systemd timers**             | `speedtest-cron` container loop (every 10 min)           | `speedtest.timer` + `publish-gh-pages.timer`         | Speedtest cadence replicated; gh-pages publish untested    |
 | **InfluxDB `_internal` DB**    | Disabled (`INFLUXDB_MONITOR_STORE_ENABLED: false`)       | Enabled by default                                   | No monitoring overhead data in sim                         |
 
 ### What you can rely on
@@ -196,7 +198,7 @@ x86-compatible inputs:
 - **Real network monitoring**: speedtest results measure the dev machine's connection, not the RPi's ISP link.
 - **Disk wear / reliability**: host SSD ≠ RPi microSD. I/O patterns and failure modes are fundamentally different.
 - **Temperature monitoring**: x86 thermal_zone0 values have no relation to BCM2711 temperatures.
-- **Scheduling / cron**: systemd timers are not part of the sim stack. The periodic speedtest + gh-pages publish cadence is untested.
+- **Scheduling / cron**: the `speedtest-cron` container replaces `speedtest.timer` but uses a sleep loop, not a real scheduler. The `publish-gh-pages.timer` is not replicated.
 
 ### Summary
 
@@ -240,9 +242,20 @@ just sim-influx-shell
 
 ### Running a speedtest
 
-The `speedtest` service uses `profiles: [run-once]` — it does not start
-with `docker compose up`. Trigger it manually:
+The `speedtest-cron` service starts automatically with `just sim-up`
+and runs a speedtest every 10 minutes (configurable via
+`SPEEDTEST_INTERVAL` in `sim/docker-compose.sim.yml`), matching the
+production `speedtest.timer` cadence.
+
+To trigger an additional one-off speedtest:
 
 ```bash
 just sim-speedtest
+```
+
+Check the cron logs:
+
+```bash
+just sim-logs-follow
+# or: docker logs -f speedtest-cron
 ```

--- a/docs/sim-environment.md
+++ b/docs/sim-environment.md
@@ -141,6 +141,76 @@ x86-compatible inputs:
 | `sim-stats`        | Show databases, retention policies, data counts           |
 | `sim-binfmt`       | Register QEMU binfmt handlers                             |
 
+## Simulation fidelity vs production RPi
+
+### What is identical
+
+| Aspect                   | Detail                                                                                                                                                  |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Container images**     | Same images, same tags, same ARM64 binaries (InfluxDB 1.8.10, Grafana 12.4.3, Telegraf 1.38.2, Chronograf 1.9.4)                                        |
+| **Compose base file**    | `docker-compose.yml` is shared — service definitions, networks, security options are the same                                                           |
+| **InfluxDB schema**      | Same databases (`telegraf`, `speedtest`), same measurements, same field keys                                                                            |
+| **Telegraf inputs**      | Same set of input plugins (cpu, mem, disk, diskio, swap, system, net, kernel, processes, netstat, interrupts, linux_sysctl_fs, docker, cpu_temperature) |
+| **Telegraf output**      | Same InfluxDB output config (database, retention policy, auth)                                                                                          |
+| **Grafana dashboards**   | Same JSON files, same datasource UIDs, same queries                                                                                                     |
+| **Grafana provisioning** | Same datasource and dashboard provider config                                                                                                           |
+| **Speedtest pipeline**   | Same Dockerfile, same `docker-entrypoint.sh`, same InfluxDB write format                                                                                |
+| **Security posture**     | Same `cap_drop: ALL`, `no-new-privileges`, `read_only` (telegraf), socket-proxy pattern                                                                 |
+| **Docker networking**    | Same bridge network, same service names, same inter-container DNS                                                                                       |
+
+### What differs
+
+| Aspect                         | Simulation (x86 + QEMU)                                  | Production (RPi4 native)                             | Impact                                                     |
+| ------------------------------ | -------------------------------------------------------- | ---------------------------------------------------- | ---------------------------------------------------------- |
+| **CPU architecture execution** | ARM64 user-mode emulated via QEMU (~10× slower)          | Native ARM Cortex-A72                                | Startup times and query latency are not representative     |
+| **CPU temperature sensor**     | `/sys/class/thermal/thermal_zone0` (x86 CPU)             | BCM2711 thermal sensor (same sysfs path on RPi OS)   | Measurement name identical, values differ (x86 vs ARM SoC) |
+| **Network interfaces**         | Wildcard (auto-detect: `docker0`, `eth0`, `veth*`, etc.) | Hardcoded `eth0` + `wlan0`                           | Sim collects more interfaces; field names identical        |
+| **Hostname**                   | `rpi-sim`                                                | Real RPi hostname (`rpi-latty`)                      | Queries using `WHERE host = 'xxx'` need adaptation         |
+| **Memory limits**              | Docker `mem_limit` constraints                           | Physical 4 GB RAM                                    | Behavior under OOM may differ (Docker OOM-kill vs kernel)  |
+| **Disk I/O**                   | Host SSD/NVMe (fast, even emulated)                      | microSD or USB SSD (slower, wear leveling)           | I/O latency and throughput not representative              |
+| **Speedtest results**          | Host network (fibre/cable, low latency)                  | RPi network (Ethernet or WiFi, different throughput) | Bandwidth and latency values differ from real ISP metrics  |
+| **Swap**                       | Host swap (may be large or absent)                       | RPi swap (typically 100 MB dphys-swapfile)           | Swap usage patterns differ                                 |
+| **Docker metrics**             | Emulated containers (QEMU overhead in all stats)         | Native containers                                    | CPU/memory per container inflated by emulation overhead    |
+| **Global tag**                 | `env = "sim"` (in telegraf-sim.conf)                     | No env tag (production telegraf.conf)                | Easy to distinguish in InfluxDB queries                    |
+| **InfluxDB capabilities**      | `cap_add` for CHOWN/DAC_OVERRIDE/etc.                    | `cap_drop: ALL` only                                 | Sim is slightly more permissive (required for QEMU init)   |
+| **Credentials**                | Hardcoded `simpass` in `.env.sim`                        | Real secrets in production `.env` (not in repo)      | No security concern — sim is local-only                    |
+| **systemd timers**             | Not present (speedtest triggered manually)               | `speedtest.timer` + `publish-gh-pages.timer`         | Scheduling pipeline not tested in sim                      |
+| **InfluxDB `_internal` DB**    | Disabled (`INFLUXDB_MONITOR_STORE_ENABLED: false`)       | Enabled by default                                   | No monitoring overhead data in sim                         |
+
+### What you can rely on
+
+**High confidence** — the simulation is a reliable proxy for:
+
+- **Grafana dashboard development**: datasources, queries, panel layout, alerting rules — all identical. What renders in sim renders the same in production.
+- **InfluxDB schema validation**: databases, measurements, field keys, retention policies — same data model.
+- **Compose / container orchestration**: service dependencies, healthchecks, volume mounts, network topology — all exercised.
+- **Telegraf plugin configuration**: same input/output plugins, same collection interval, same data format.
+- **Speedtest data pipeline**: same Dockerfile, same entrypoint, same InfluxDB write path. Only the measured values differ.
+- **Security configuration**: same security options and capability drops. The `cap_add` overrides in sim are an exception, documented above.
+- **Provisioning-as-code workflow**: if dashboards and datasources provision correctly in sim, they will in production.
+
+**Low confidence** — do not trust the simulation for:
+
+- **Performance benchmarking**: QEMU adds ~10× overhead. CPU, memory, I/O metrics reflect the x86 host + emulation, not RPi4 hardware.
+- **Capacity planning**: memory pressure, OOM behavior, swap usage are all distorted by the emulation layer and Docker memory limits.
+- **Real network monitoring**: speedtest results measure the dev machine's connection, not the RPi's ISP link.
+- **Disk wear / reliability**: host SSD ≠ RPi microSD. I/O patterns and failure modes are fundamentally different.
+- **Temperature monitoring**: x86 thermal_zone0 values have no relation to BCM2711 temperatures.
+- **Scheduling / cron**: systemd timers are not part of the sim stack. The periodic speedtest + gh-pages publish cadence is untested.
+
+### Summary
+
+The simulation is a **functional test environment**, not a **performance
+replica**. It validates that all components wire together correctly,
+dashboards render with real data, and the provisioning pipeline works
+end-to-end. It does _not_ replicate RPi4 hardware characteristics
+(CPU speed, thermal behavior, SD card I/O, WiFi stability).
+
+Rule of thumb: if it works in sim, the _configuration_ is correct. If
+it doesn't work on the RPi, look at _hardware-specific_ factors (SD card
+corruption, thermal throttling, network driver issues, kernel
+differences).
+
 ## Troubleshooting
 
 ### InfluxDB fails to start (permission denied)

--- a/docs/sim-environment.md
+++ b/docs/sim-environment.md
@@ -36,6 +36,7 @@ InfluxDB API: <http://localhost:8086> (admin / simpass)
 ```
 sim/.env.sim                  ← credentials (safe local defaults)
 sim/docker-compose.sim.yml    ← ARM64 override layer
+sim/influxdb-init.iql         ← creates databases + grants on first boot
 sim/telegraf-sim.conf         ← Telegraf config adapted for x86 host
 sim/speedtest-loop.sh         ← periodic speedtest loop (replaces systemd timer)
 docker-compose.yml            ← base compose (shared with production)
@@ -57,16 +58,17 @@ production deployment on the same host.
 
 ### What the sim overlay changes
 
-| Service      | Override                                                  | Why                                                                               |
-| ------------ | --------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| All services | `platform: linux/arm64`                                   | Force ARM64 emulation via QEMU                                                    |
-| All services | `mem_limit` / `memswap_limit`                             | Simulate RPi4 4 GB memory budget                                                  |
-| influxdb     | `cap_add: CHOWN, DAC_OVERRIDE, SETUID, SETGID, FOWNER`    | Entrypoint needs these to init data dir (base compose has `cap_drop: ALL`)        |
-| influxdb     | Healthcheck: `timeout 30s, retries 10, start_period 120s` | QEMU emulation is ~10× slower than native                                         |
-| influxdb     | `ports: 127.0.0.1:8086:8086`                              | Expose for external tooling                                                       |
-| influxdb     | `INFLUXDB_MONITOR_STORE_ENABLED: false`                   | Skip `_internal` database to save resources                                       |
-| telegraf     | `hostname: rpi-sim`, custom `telegraf-sim.conf`           | x86-compatible inputs (thermal_zone0 instead of BCM2711, wildcard net interfaces) |
-| speedtest    | `platform: linux/arm64` + ARM64 build                     | Build the speedtest image for ARM64                                               |
+| Service      | Override                                                      | Why                                                                                |
+| ------------ | ------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| All services | `platform: linux/arm64`                                       | Force ARM64 emulation via QEMU                                                     |
+| All services | `mem_limit` / `memswap_limit`                                 | Simulate RPi4 4 GB memory budget                                                   |
+| influxdb     | `cap_add: CHOWN, DAC_OVERRIDE, SETUID, SETGID, FOWNER`        | Entrypoint needs these to init data dir (base compose has `cap_drop: ALL`)         |
+| influxdb     | Healthcheck: `timeout 30s, retries 10, start_period 120s`     | QEMU emulation is ~10× slower than native                                          |
+| influxdb     | `ports: 127.0.0.1:8086:8086`                                  | Expose for external tooling                                                        |
+| influxdb     | `INFLUXDB_MONITOR_STORE_ENABLED: false`                       | Skip `_internal` database to save resources                                        |
+| telegraf     | `hostname: rpi-sim`, custom `telegraf-sim.conf`               | x86-compatible inputs (thermal_zone0 instead of BCM2711, wildcard net interfaces)  |
+| influxdb     | `influxdb-init.iql` mounted in `/docker-entrypoint-initdb.d/` | Creates `telegraf` + `speedtest` databases and grants on first boot (empty volume) |
+| speedtest    | `platform: linux/arm64` + ARM64 build + admin credentials     | Build the speedtest image for ARM64; use admin creds for `CREATE DATABASE`         |
 
 ### Memory budget (RPi4 — 4 GB)
 
@@ -230,14 +232,18 @@ ARM64 emulation on x86 is ~10× slower. The sim overlay increases
 
 ### Empty dashboards after first boot
 
-InfluxDB auto-creates the `telegraf` and `speedtest` databases on
-first start, but the `telegraf` user may lack privileges. If dashboards
-show no data, grant access:
+The init script (`sim/influxdb-init.iql`) automatically creates both
+databases and grants `ALL PRIVILEGES` to the `telegraf` user on first
+boot. If dashboards still show no data after startup:
+
+1. Verify InfluxDB is healthy: `just sim-status`
+2. Check that databases exist: `just sim-stats`
+3. If the schema is corrupted (e.g. field type conflict), nuke and
+   recreate from scratch:
 
 ```bash
-just sim-influx-shell
-> GRANT ALL ON telegraf TO telegraf
-> GRANT ALL ON speedtest TO telegraf
+just sim-nuke
+just sim-up
 ```
 
 ### Running a speedtest
@@ -259,3 +265,63 @@ Check the cron logs:
 just sim-logs-follow
 # or: docker logs -f speedtest-cron
 ```
+
+## CI / CD — Nightly sim smoke tests
+
+A GitHub Actions workflow (`.github/workflows/sim-e2e-nightly.yml`)
+runs the full sim stack on an Ubuntu runner every night and validates
+the deployment end-to-end.
+
+### Schedule
+
+- **Nightly**: 03:30 UTC (offset from the existing GH Pages E2E at 03:00)
+- **Manual**: `workflow_dispatch` — trigger from the Actions tab to
+  validate a PR before merging
+
+### Pipeline stages
+
+```
+binfmt → build → up → wait (InfluxDB healthy + Telegraf data) → smoke tests → teardown
+```
+
+| Stage                     | Duration (est.) | What it validates                                         |
+| ------------------------- | --------------- | --------------------------------------------------------- |
+| Register QEMU binfmt      | ~5s             | ARM64 emulation available on the runner                   |
+| Build + start stack       | ~5 min          | Dockerfile builds, all images pull, compose orchestration |
+| Wait for InfluxDB healthy | ~2-3 min        | Init script runs, databases + grants created              |
+| Wait for Telegraf data    | ~90s            | Collection interval works under QEMU emulation            |
+| Smoke tests               | ~15s            | 7 test sections (see below)                               |
+| Teardown                  | ~10s            | Containers + volumes removed                              |
+| **Total**                 | **~12-15 min**  |                                                           |
+
+### What the smoke tests validate
+
+The test script (`scripts/test-sim-stack.sh`) runs 7 sections:
+
+1. **Service health** — Grafana, InfluxDB, Chronograf respond on their
+   respective ports
+2. **Grafana datasources** — 2 datasources exist (`InfluxDB`,
+   `InfluxDB-Speedtest`), connectivity OK
+3. **Grafana dashboards** — 4 dashboards provisioned (by UID)
+4. **InfluxDB schema** — `telegraf` + `speedtest` databases exist,
+   `telegraf` user has `ALL PRIVILEGES` on both
+5. **Telegraf pipeline** — CPU data points written in the last 5 minutes
+   (proves Telegraf → InfluxDB is working)
+6. **Speedtest write path** — Injects a synthetic data point via the
+   InfluxDB HTTP API, verifies it is queryable, then cleans up (avoids
+   running a real speedtest — no network dependency, no QEMU slowness)
+7. **Container state** — All 6 containers running (grafana, influxdb,
+   chronograf, telegraf, docker-socket-proxy, speedtest-cron)
+
+### Running locally
+
+```bash
+just sim-up
+# Wait ~2 min for InfluxDB + Telegraf to settle
+./scripts/test-sim-stack.sh
+```
+
+### Failure artifacts
+
+On failure, the workflow uploads a `sim-e2e-logs` artifact containing
+the full Docker Compose logs and container status (retained 7 days).

--- a/grafana/dashboards/docker-containers.json
+++ b/grafana/dashboards/docker-containers.json
@@ -1,536 +1,845 @@
 {
-    "dashboard": {
-        "uid": "rpi-docker-dashboard",
-        "title": "Docker Containers",
-        "tags": ["docker", "telegraf"],
-        "timezone": "browser",
-        "refresh": "30s",
-        "time": {
-            "from": "now-1h",
-            "to": "now"
+  "uid": "rpi-docker-dashboard",
+  "title": "Docker Containers",
+  "tags": [
+    "docker",
+    "telegraf"
+  ],
+  "timezone": "browser",
+  "refresh": "30s",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "container",
+        "type": "query",
+        "datasource": {
+          "uid": "2QPKy_O4k",
+          "type": "influxdb"
         },
-        "templating": {
-            "list": [
-                {
-                    "name": "container",
-                    "type": "query",
-                    "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                    "query": "SHOW TAG VALUES FROM docker_container_cpu WITH KEY = container_name",
-                    "multi": true,
-                    "includeAll": true,
-                    "current": { "text": "All", "value": "$__all" },
-                    "refresh": 2
-                }
+        "query": "SHOW TAG VALUES FROM docker_container_cpu WITH KEY = container_name",
+        "multi": true,
+        "includeAll": true,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "refresh": 2
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Running Containers",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "uid": "2QPKy_O4k",
+        "type": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
             ]
+          }
         },
-        "panels": [
-            {
-                "id": 1,
-                "type": "stat",
-                "title": "Running Containers",
-                "gridPos": { "h": 4, "w": 4, "x": 0, "y": 0 },
-                "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                "fieldConfig": {
-                    "defaults": {
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                { "color": "red", "value": null },
-                                { "color": "green", "value": 1 }
-                            ]
-                        }
-                    },
-                    "overrides": []
-                },
-                "options": {
-                    "graphMode": "none",
-                    "colorMode": "background",
-                    "reduceOptions": { "calcs": ["lastNotNull"] },
-                    "textMode": "auto"
-                },
-                "targets": [
-                    {
-                        "refId": "A",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT last(\"n_containers_running\") FROM \"docker\" WHERE $timeFilter",
-                        "rawQuery": true,
-                        "resultFormat": "time_series"
-                    }
-                ]
-            },
-            {
-                "id": 2,
-                "type": "stat",
-                "title": "Stopped",
-                "gridPos": { "h": 4, "w": 4, "x": 4, "y": 0 },
-                "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                "fieldConfig": {
-                    "defaults": {
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                { "color": "green", "value": null },
-                                { "color": "orange", "value": 1 }
-                            ]
-                        }
-                    },
-                    "overrides": []
-                },
-                "options": {
-                    "graphMode": "none",
-                    "colorMode": "background",
-                    "reduceOptions": { "calcs": ["lastNotNull"] },
-                    "textMode": "auto"
-                },
-                "targets": [
-                    {
-                        "refId": "A",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT last(\"n_containers_stopped\") FROM \"docker\" WHERE $timeFilter",
-                        "rawQuery": true,
-                        "resultFormat": "time_series"
-                    }
-                ]
-            },
-            {
-                "id": 3,
-                "type": "stat",
-                "title": "Total Images",
-                "gridPos": { "h": 4, "w": 4, "x": 8, "y": 0 },
-                "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                "fieldConfig": {
-                    "defaults": {
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [{ "color": "blue", "value": null }]
-                        }
-                    },
-                    "overrides": []
-                },
-                "options": {
-                    "graphMode": "none",
-                    "colorMode": "background",
-                    "reduceOptions": { "calcs": ["lastNotNull"] },
-                    "textMode": "auto"
-                },
-                "targets": [
-                    {
-                        "refId": "A",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT last(\"n_images\") FROM \"docker\" WHERE $timeFilter",
-                        "rawQuery": true,
-                        "resultFormat": "time_series"
-                    }
-                ]
-            },
-            {
-                "id": 4,
-                "type": "stat",
-                "title": "Total CPU %",
-                "gridPos": { "h": 4, "w": 4, "x": 12, "y": 0 },
-                "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                "fieldConfig": {
-                    "defaults": {
-                        "unit": "percent",
-                        "decimals": 1,
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                { "color": "green", "value": null },
-                                { "color": "yellow", "value": 50 },
-                                { "color": "orange", "value": 80 },
-                                { "color": "red", "value": 100 }
-                            ]
-                        }
-                    },
-                    "overrides": []
-                },
-                "options": {
-                    "graphMode": "area",
-                    "colorMode": "background",
-                    "reduceOptions": { "calcs": ["lastNotNull"] },
-                    "textMode": "auto"
-                },
-                "targets": [
-                    {
-                        "refId": "A",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT sum(\"usage_percent\") FROM \"docker_container_cpu\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
-                        "rawQuery": true,
-                        "resultFormat": "time_series"
-                    }
-                ]
-            },
-            {
-                "id": 5,
-                "type": "stat",
-                "title": "Total RAM",
-                "gridPos": { "h": 4, "w": 4, "x": 16, "y": 0 },
-                "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                "fieldConfig": {
-                    "defaults": {
-                        "unit": "bytes",
-                        "decimals": 0,
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                { "color": "green", "value": null },
-                                { "color": "yellow", "value": 1073741824 },
-                                { "color": "red", "value": 3221225472 }
-                            ]
-                        }
-                    },
-                    "overrides": []
-                },
-                "options": {
-                    "graphMode": "area",
-                    "colorMode": "background",
-                    "reduceOptions": { "calcs": ["lastNotNull"] },
-                    "textMode": "auto"
-                },
-                "targets": [
-                    {
-                        "refId": "A",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT sum(\"usage\") FROM \"docker_container_mem\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
-                        "rawQuery": true,
-                        "resultFormat": "time_series"
-                    }
-                ]
-            },
-            {
-                "id": 6,
-                "type": "stat",
-                "title": "Total Net RX",
-                "gridPos": { "h": 4, "w": 4, "x": 20, "y": 0 },
-                "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                "fieldConfig": {
-                    "defaults": {
-                        "unit": "decbytes",
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [{ "color": "blue", "value": null }]
-                        }
-                    },
-                    "overrides": []
-                },
-                "options": {
-                    "graphMode": "area",
-                    "colorMode": "background",
-                    "reduceOptions": { "calcs": ["lastNotNull"] },
-                    "textMode": "auto"
-                },
-                "targets": [
-                    {
-                        "refId": "A",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT sum(\"rx_bytes\") FROM \"docker_container_net\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
-                        "rawQuery": true,
-                        "resultFormat": "time_series"
-                    }
-                ]
-            },
-            {
-                "id": 10,
-                "type": "timeseries",
-                "title": "CPU Usage per Container",
-                "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
-                "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                "fieldConfig": {
-                    "defaults": {
-                        "unit": "percent",
-                        "min": 0,
-                        "color": { "mode": "palette-classic" },
-                        "custom": {
-                            "lineWidth": 1,
-                            "fillOpacity": 20,
-                            "gradientMode": "scheme",
-                            "showPoints": "never",
-                            "stacking": { "mode": "none" }
-                        }
-                    },
-                    "overrides": []
-                },
-                "options": {
-                    "legend": {
-                        "displayMode": "table",
-                        "placement": "right",
-                        "calcs": ["mean", "max", "lastNotNull"]
-                    },
-                    "tooltip": { "mode": "multi", "sort": "desc" }
-                },
-                "targets": [
-                    {
-                        "refId": "A",
-                        "alias": "$tag_container_name",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT mean(\"usage_percent\") FROM \"docker_container_cpu\" WHERE (\"container_name\" =~ /^$container$/) AND $timeFilter GROUP BY time($__interval), \"container_name\" fill(none)",
-                        "rawQuery": true,
-                        "resultFormat": "time_series"
-                    }
-                ]
-            },
-            {
-                "id": 11,
-                "type": "timeseries",
-                "title": "Memory Usage per Container",
-                "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
-                "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                "fieldConfig": {
-                    "defaults": {
-                        "unit": "bytes",
-                        "min": 0,
-                        "color": { "mode": "palette-classic" },
-                        "custom": {
-                            "lineWidth": 1,
-                            "fillOpacity": 20,
-                            "gradientMode": "scheme",
-                            "showPoints": "never",
-                            "stacking": { "mode": "none" }
-                        }
-                    },
-                    "overrides": []
-                },
-                "options": {
-                    "legend": {
-                        "displayMode": "table",
-                        "placement": "right",
-                        "calcs": ["mean", "max", "lastNotNull"]
-                    },
-                    "tooltip": { "mode": "multi", "sort": "desc" }
-                },
-                "targets": [
-                    {
-                        "refId": "A",
-                        "alias": "$tag_container_name",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT mean(\"usage\") FROM \"docker_container_mem\" WHERE (\"container_name\" =~ /^$container$/) AND $timeFilter GROUP BY time($__interval), \"container_name\" fill(none)",
-                        "rawQuery": true,
-                        "resultFormat": "time_series"
-                    }
-                ]
-            },
-            {
-                "id": 12,
-                "type": "timeseries",
-                "title": "Memory % per Container",
-                "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
-                "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                "fieldConfig": {
-                    "defaults": {
-                        "unit": "percent",
-                        "min": 0,
-                        "max": 100,
-                        "color": { "mode": "palette-classic" },
-                        "custom": {
-                            "lineWidth": 1,
-                            "fillOpacity": 20,
-                            "gradientMode": "scheme",
-                            "showPoints": "never"
-                        }
-                    },
-                    "overrides": []
-                },
-                "options": {
-                    "legend": {
-                        "displayMode": "table",
-                        "placement": "right",
-                        "calcs": ["mean", "max", "lastNotNull"]
-                    },
-                    "tooltip": { "mode": "multi", "sort": "desc" }
-                },
-                "targets": [
-                    {
-                        "refId": "A",
-                        "alias": "$tag_container_name",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT mean(\"usage_percent\") FROM \"docker_container_mem\" WHERE (\"container_name\" =~ /^$container$/) AND $timeFilter GROUP BY time($__interval), \"container_name\" fill(none)",
-                        "rawQuery": true,
-                        "resultFormat": "time_series"
-                    }
-                ]
-            },
-            {
-                "id": 13,
-                "type": "timeseries",
-                "title": "Network I/O per Container",
-                "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
-                "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                "fieldConfig": {
-                    "defaults": {
-                        "unit": "Bps",
-                        "color": { "mode": "palette-classic" },
-                        "custom": {
-                            "lineWidth": 1,
-                            "fillOpacity": 10,
-                            "gradientMode": "scheme",
-                            "showPoints": "never"
-                        }
-                    },
-                    "overrides": []
-                },
-                "options": {
-                    "legend": {
-                        "displayMode": "table",
-                        "placement": "right",
-                        "calcs": ["mean", "max"]
-                    },
-                    "tooltip": { "mode": "multi", "sort": "desc" }
-                },
-                "targets": [
-                    {
-                        "refId": "A",
-                        "alias": "$tag_container_name RX",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT non_negative_derivative(mean(\"rx_bytes\"), 1s) FROM \"docker_container_net\" WHERE (\"container_name\" =~ /^$container$/) AND $timeFilter GROUP BY time($__interval), \"container_name\" fill(none)",
-                        "rawQuery": true,
-                        "resultFormat": "time_series"
-                    },
-                    {
-                        "refId": "B",
-                        "alias": "$tag_container_name TX",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT non_negative_derivative(mean(\"tx_bytes\"), 1s) * -1 FROM \"docker_container_net\" WHERE (\"container_name\" =~ /^$container$/) AND $timeFilter GROUP BY time($__interval), \"container_name\" fill(none)",
-                        "rawQuery": true,
-                        "resultFormat": "time_series"
-                    }
-                ]
-            },
-            {
-                "id": 14,
-                "type": "timeseries",
-                "title": "Block I/O per Container",
-                "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
-                "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                "fieldConfig": {
-                    "defaults": {
-                        "unit": "Bps",
-                        "color": { "mode": "palette-classic" },
-                        "custom": {
-                            "lineWidth": 1,
-                            "fillOpacity": 10,
-                            "gradientMode": "scheme",
-                            "showPoints": "never"
-                        }
-                    },
-                    "overrides": []
-                },
-                "options": {
-                    "legend": {
-                        "displayMode": "table",
-                        "placement": "right",
-                        "calcs": ["mean", "max"]
-                    },
-                    "tooltip": { "mode": "multi", "sort": "desc" }
-                },
-                "targets": [
-                    {
-                        "refId": "A",
-                        "alias": "$tag_container_name Read",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT non_negative_derivative(mean(\"io_service_bytes_recursive_read\"), 1s) FROM \"docker_container_blkio\" WHERE (\"container_name\" =~ /^$container$/) AND $timeFilter GROUP BY time($__interval), \"container_name\" fill(none)",
-                        "rawQuery": true,
-                        "resultFormat": "time_series"
-                    },
-                    {
-                        "refId": "B",
-                        "alias": "$tag_container_name Write",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT non_negative_derivative(mean(\"io_service_bytes_recursive_write\"), 1s) * -1 FROM \"docker_container_blkio\" WHERE (\"container_name\" =~ /^$container$/) AND $timeFilter GROUP BY time($__interval), \"container_name\" fill(none)",
-                        "rawQuery": true,
-                        "resultFormat": "time_series"
-                    }
-                ]
-            },
-            {
-                "id": 15,
-                "type": "table",
-                "title": "Container Status",
-                "gridPos": { "h": 8, "w": 12, "x": 12, "y": 20 },
-                "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                "fieldConfig": {
-                    "defaults": {},
-                    "overrides": [
-                        {
-                            "matcher": { "id": "byName", "options": "uptime_ns" },
-                            "properties": [{ "id": "unit", "value": "ns" }]
-                        },
-                        {
-                            "matcher": { "id": "byName", "options": "usage_percent" },
-                            "properties": [
-                                { "id": "unit", "value": "percent" },
-                                { "id": "decimals", "value": 1 },
-                                {
-                                    "id": "thresholds",
-                                    "value": {
-                                        "mode": "absolute",
-                                        "steps": [
-                                            { "color": "green", "value": null },
-                                            { "color": "yellow", "value": 25 },
-                                            { "color": "orange", "value": 50 },
-                                            { "color": "red", "value": 80 }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "id": "custom.cellOptions",
-                                    "value": { "type": "color-background" }
-                                }
-                            ]
-                        },
-                        {
-                            "matcher": { "id": "byName", "options": "mem_usage" },
-                            "properties": [{ "id": "unit", "value": "bytes" }]
-                        }
-                    ]
-                },
-                "options": {
-                    "showHeader": true,
-                    "sortBy": [{ "displayName": "usage_percent", "desc": true }]
-                },
-                "transformations": [
-                    {
-                        "id": "organize",
-                        "options": {
-                            "excludeByName": { "Time": true },
-                            "renameByName": {
-                                "container_name": "Container",
-                                "usage_percent": "CPU %",
-                                "mem_usage": "Memory",
-                                "uptime_ns": "Uptime",
-                                "restart_count": "Restarts",
-                                "oomkilled": "OOM Killed"
-                            }
-                        }
-                    }
-                ],
-                "targets": [
-                    {
-                        "refId": "A",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT last(\"usage_percent\") AS \"usage_percent\" FROM \"docker_container_cpu\" WHERE $timeFilter GROUP BY \"container_name\"",
-                        "rawQuery": true,
-                        "resultFormat": "table"
-                    },
-                    {
-                        "refId": "B",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT last(\"usage\") AS \"mem_usage\" FROM \"docker_container_mem\" WHERE $timeFilter GROUP BY \"container_name\"",
-                        "rawQuery": true,
-                        "resultFormat": "table"
-                    },
-                    {
-                        "refId": "C",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT last(\"uptime_ns\") AS \"uptime_ns\", last(\"restart_count\") AS \"restart_count\", last(\"oomkilled\") AS \"oomkilled\" FROM \"docker_container_status\" WHERE $timeFilter GROUP BY \"container_name\"",
-                        "rawQuery": true,
-                        "resultFormat": "table"
-                    }
-                ]
-            }
-        ],
-        "schemaVersion": 39
+        "overrides": []
+      },
+      "options": {
+        "graphMode": "none",
+        "colorMode": "background",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT last(\"n_containers_running\") FROM \"docker\" WHERE $timeFilter",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ]
     },
-    "folderUid": "",
-    "overwrite": true
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Stopped",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "datasource": {
+        "uid": "2QPKy_O4k",
+        "type": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "graphMode": "none",
+        "colorMode": "background",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT last(\"n_containers_stopped\") FROM \"docker\" WHERE $timeFilter",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Total Images",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
+      "datasource": {
+        "uid": "2QPKy_O4k",
+        "type": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "graphMode": "none",
+        "colorMode": "background",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT last(\"n_images\") FROM \"docker\" WHERE $timeFilter",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Total CPU %",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "datasource": {
+        "uid": "2QPKy_O4k",
+        "type": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "orange",
+                "value": 80
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "graphMode": "area",
+        "colorMode": "background",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT sum(\"usage_percent\") FROM \"docker_container_cpu\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Total RAM",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "datasource": {
+        "uid": "2QPKy_O4k",
+        "type": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1073741824
+              },
+              {
+                "color": "red",
+                "value": 3221225472
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "graphMode": "area",
+        "colorMode": "background",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT sum(\"usage\") FROM \"docker_container_mem\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "Total Net RX",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "datasource": {
+        "uid": "2QPKy_O4k",
+        "type": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "graphMode": "area",
+        "colorMode": "background",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT sum(\"rx_bytes\") FROM \"docker_container_net\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "CPU Usage per Container",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "datasource": {
+        "uid": "2QPKy_O4k",
+        "type": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 20,
+            "gradientMode": "scheme",
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "alias": "$tag_container_name",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT mean(\"usage_percent\") FROM \"docker_container_cpu\" WHERE (\"container_name\" =~ /^$container$/) AND $timeFilter GROUP BY time($__interval), \"container_name\" fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Memory Usage per Container",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "datasource": {
+        "uid": "2QPKy_O4k",
+        "type": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "min": 0,
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 20,
+            "gradientMode": "scheme",
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "alias": "$tag_container_name",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT mean(\"usage\") FROM \"docker_container_mem\" WHERE (\"container_name\" =~ /^$container$/) AND $timeFilter GROUP BY time($__interval), \"container_name\" fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Memory % per Container",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "datasource": {
+        "uid": "2QPKy_O4k",
+        "type": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 20,
+            "gradientMode": "scheme",
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "alias": "$tag_container_name",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT mean(\"usage_percent\") FROM \"docker_container_mem\" WHERE (\"container_name\" =~ /^$container$/) AND $timeFilter GROUP BY time($__interval), \"container_name\" fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Network I/O per Container",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "datasource": {
+        "uid": "2QPKy_O4k",
+        "type": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "scheme",
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "alias": "$tag_container_name RX",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT non_negative_derivative(mean(\"rx_bytes\"), 1s) FROM \"docker_container_net\" WHERE (\"container_name\" =~ /^$container$/) AND $timeFilter GROUP BY time($__interval), \"container_name\" fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        },
+        {
+          "refId": "B",
+          "alias": "$tag_container_name TX",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT non_negative_derivative(mean(\"tx_bytes\"), 1s) * -1 FROM \"docker_container_net\" WHERE (\"container_name\" =~ /^$container$/) AND $timeFilter GROUP BY time($__interval), \"container_name\" fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "type": "timeseries",
+      "title": "Block I/O per Container",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "datasource": {
+        "uid": "2QPKy_O4k",
+        "type": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "scheme",
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "alias": "$tag_container_name Read",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT non_negative_derivative(mean(\"io_service_bytes_recursive_read\"), 1s) FROM \"docker_container_blkio\" WHERE (\"container_name\" =~ /^$container$/) AND $timeFilter GROUP BY time($__interval), \"container_name\" fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        },
+        {
+          "refId": "B",
+          "alias": "$tag_container_name Write",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT non_negative_derivative(mean(\"io_service_bytes_recursive_write\"), 1s) * -1 FROM \"docker_container_blkio\" WHERE (\"container_name\" =~ /^$container$/) AND $timeFilter GROUP BY time($__interval), \"container_name\" fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ]
+    },
+    {
+      "id": 15,
+      "type": "table",
+      "title": "Container Status",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "datasource": {
+        "uid": "2QPKy_O4k",
+        "type": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "uptime_ns"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ns"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "usage_percent"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 25
+                    },
+                    {
+                      "color": "orange",
+                      "value": 50
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "mem_usage"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "usage_percent",
+            "desc": true
+          }
+        ]
+      },
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "renameByName": {
+              "container_name": "Container",
+              "usage_percent": "CPU %",
+              "mem_usage": "Memory",
+              "uptime_ns": "Uptime",
+              "restart_count": "Restarts",
+              "oomkilled": "OOM Killed"
+            }
+          }
+        }
+      ],
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT last(\"usage_percent\") AS \"usage_percent\" FROM \"docker_container_cpu\" WHERE $timeFilter GROUP BY \"container_name\"",
+          "rawQuery": true,
+          "resultFormat": "table"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT last(\"usage\") AS \"mem_usage\" FROM \"docker_container_mem\" WHERE $timeFilter GROUP BY \"container_name\"",
+          "rawQuery": true,
+          "resultFormat": "table"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT last(\"uptime_ns\") AS \"uptime_ns\", last(\"restart_count\") AS \"restart_count\", last(\"oomkilled\") AS \"oomkilled\" FROM \"docker_container_status\" WHERE $timeFilter GROUP BY \"container_name\"",
+          "rawQuery": true,
+          "resultFormat": "table"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 39
 }

--- a/grafana/dashboards/rpi-alerts.json
+++ b/grafana/dashboards/rpi-alerts.json
@@ -1,545 +1,873 @@
 {
-    "dashboard": {
-        "uid": "rpi-alerts-dashboard",
-        "title": "RPi Alerts Overview",
-        "tags": ["alerts", "system", "telegraf"],
-        "timezone": "browser",
-        "refresh": "30s",
-        "time": {
-            "from": "now-1h",
-            "to": "now"
+  "uid": "rpi-alerts-dashboard",
+  "title": "RPi Alerts Overview",
+  "tags": [
+    "alerts",
+    "system",
+    "telegraf"
+  ],
+  "timezone": "browser",
+  "refresh": "30s",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "templating": {
+    "list": []
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "CPU Usage",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "uid": "2QPKy_O4k",
+        "type": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 60
+              },
+              {
+                "color": "orange",
+                "value": 80
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "min": 0,
+          "max": 100
         },
-        "templating": {
-            "list": []
+        "overrides": []
+      },
+      "options": {
+        "graphMode": "area",
+        "colorMode": "background",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
         },
-        "panels": [
-            {
-                "id": 1,
-                "type": "stat",
-                "title": "CPU Usage",
-                "gridPos": { "h": 4, "w": 4, "x": 0, "y": 0 },
-                "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                "fieldConfig": {
-                    "defaults": {
-                        "unit": "percent",
-                        "decimals": 1,
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                { "color": "green", "value": null },
-                                { "color": "yellow", "value": 60 },
-                                { "color": "orange", "value": 80 },
-                                { "color": "red", "value": 90 }
-                            ]
-                        },
-                        "min": 0,
-                        "max": 100
-                    },
-                    "overrides": []
-                },
-                "options": {
-                    "graphMode": "area",
-                    "colorMode": "background",
-                    "reduceOptions": { "calcs": ["lastNotNull"] },
-                    "textMode": "auto"
-                },
-                "targets": [
-                    {
-                        "refId": "A",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT 100 - mean(\"usage_idle\") FROM \"cpu\" WHERE (\"cpu\" = 'cpu-total') AND $timeFilter GROUP BY time($__interval) fill(none)",
-                        "rawQuery": true,
-                        "resultFormat": "time_series"
-                    }
-                ]
-            },
-            {
-                "id": 2,
-                "type": "stat",
-                "title": "CPU Temp",
-                "gridPos": { "h": 4, "w": 4, "x": 4, "y": 0 },
-                "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                "fieldConfig": {
-                    "defaults": {
-                        "unit": "celsius",
-                        "decimals": 1,
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                { "color": "green", "value": null },
-                                { "color": "yellow", "value": 55 },
-                                { "color": "orange", "value": 70 },
-                                { "color": "red", "value": 80 }
-                            ]
-                        }
-                    },
-                    "overrides": []
-                },
-                "options": {
-                    "graphMode": "area",
-                    "colorMode": "background",
-                    "reduceOptions": { "calcs": ["lastNotNull"] },
-                    "textMode": "auto"
-                },
-                "targets": [
-                    {
-                        "refId": "A",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT mean(\"value\") / 1000 FROM \"cpu_temperature\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
-                        "rawQuery": true,
-                        "resultFormat": "time_series"
-                    }
-                ]
-            },
-            {
-                "id": 3,
-                "type": "stat",
-                "title": "RAM Usage",
-                "gridPos": { "h": 4, "w": 4, "x": 8, "y": 0 },
-                "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                "fieldConfig": {
-                    "defaults": {
-                        "unit": "percent",
-                        "decimals": 1,
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                { "color": "green", "value": null },
-                                { "color": "yellow", "value": 70 },
-                                { "color": "orange", "value": 85 },
-                                { "color": "red", "value": 95 }
-                            ]
-                        },
-                        "min": 0,
-                        "max": 100
-                    },
-                    "overrides": []
-                },
-                "options": {
-                    "graphMode": "area",
-                    "colorMode": "background",
-                    "reduceOptions": { "calcs": ["lastNotNull"] },
-                    "textMode": "auto"
-                },
-                "targets": [
-                    {
-                        "refId": "A",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT mean(\"used_percent\") FROM \"mem\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
-                        "rawQuery": true,
-                        "resultFormat": "time_series"
-                    }
-                ]
-            },
-            {
-                "id": 4,
-                "type": "stat",
-                "title": "Swap Usage",
-                "gridPos": { "h": 4, "w": 4, "x": 12, "y": 0 },
-                "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                "fieldConfig": {
-                    "defaults": {
-                        "unit": "percent",
-                        "decimals": 1,
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                { "color": "green", "value": null },
-                                { "color": "yellow", "value": 30 },
-                                { "color": "orange", "value": 50 },
-                                { "color": "red", "value": 75 }
-                            ]
-                        },
-                        "min": 0,
-                        "max": 100
-                    },
-                    "overrides": []
-                },
-                "options": {
-                    "graphMode": "area",
-                    "colorMode": "background",
-                    "reduceOptions": { "calcs": ["lastNotNull"] },
-                    "textMode": "auto"
-                },
-                "targets": [
-                    {
-                        "refId": "A",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT mean(\"used_percent\") FROM \"swap\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
-                        "rawQuery": true,
-                        "resultFormat": "time_series"
-                    }
-                ]
-            },
-            {
-                "id": 5,
-                "type": "stat",
-                "title": "Disk Usage /",
-                "gridPos": { "h": 4, "w": 4, "x": 16, "y": 0 },
-                "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                "fieldConfig": {
-                    "defaults": {
-                        "unit": "percent",
-                        "decimals": 1,
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                { "color": "green", "value": null },
-                                { "color": "yellow", "value": 70 },
-                                { "color": "orange", "value": 85 },
-                                { "color": "red", "value": 95 }
-                            ]
-                        },
-                        "min": 0,
-                        "max": 100
-                    },
-                    "overrides": []
-                },
-                "options": {
-                    "graphMode": "area",
-                    "colorMode": "background",
-                    "reduceOptions": { "calcs": ["lastNotNull"] },
-                    "textMode": "auto"
-                },
-                "targets": [
-                    {
-                        "refId": "A",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT mean(\"used_percent\") FROM \"disk\" WHERE (\"path\" = '/') AND $timeFilter GROUP BY time($__interval) fill(none)",
-                        "rawQuery": true,
-                        "resultFormat": "time_series"
-                    }
-                ]
-            },
-            {
-                "id": 6,
-                "type": "stat",
-                "title": "Load Avg (1m)",
-                "gridPos": { "h": 4, "w": 4, "x": 20, "y": 0 },
-                "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                "fieldConfig": {
-                    "defaults": {
-                        "decimals": 2,
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                { "color": "green", "value": null },
-                                { "color": "yellow", "value": 2 },
-                                { "color": "orange", "value": 4 },
-                                { "color": "red", "value": 6 }
-                            ]
-                        },
-                        "min": 0
-                    },
-                    "overrides": []
-                },
-                "options": {
-                    "graphMode": "area",
-                    "colorMode": "background",
-                    "reduceOptions": { "calcs": ["lastNotNull"] },
-                    "textMode": "auto"
-                },
-                "targets": [
-                    {
-                        "refId": "A",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT mean(\"load1\") FROM \"system\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
-                        "rawQuery": true,
-                        "resultFormat": "time_series"
-                    }
-                ]
-            },
-            {
-                "id": 10,
-                "type": "timeseries",
-                "title": "CPU Usage",
-                "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
-                "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                "fieldConfig": {
-                    "defaults": {
-                        "unit": "percent",
-                        "min": 0,
-                        "max": 100,
-                        "color": { "mode": "palette-classic" },
-                        "custom": {
-                            "lineWidth": 1,
-                            "fillOpacity": 20,
-                            "gradientMode": "scheme",
-                            "axisLabel": "",
-                            "showPoints": "never",
-                            "thresholdsStyle": { "mode": "line+area" }
-                        },
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                { "color": "transparent", "value": null },
-                                { "color": "red", "value": 80 }
-                            ]
-                        }
-                    },
-                    "overrides": []
-                },
-                "options": {
-                    "legend": { "displayMode": "list", "placement": "bottom" },
-                    "tooltip": { "mode": "multi", "sort": "desc" }
-                },
-                "targets": [
-                    {
-                        "refId": "A",
-                        "alias": "CPU Total",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT 100 - mean(\"usage_idle\") FROM \"cpu\" WHERE (\"cpu\" = 'cpu-total') AND $timeFilter GROUP BY time($__interval) fill(none)",
-                        "rawQuery": true,
-                        "resultFormat": "time_series"
-                    }
-                ]
-            },
-            {
-                "id": 11,
-                "type": "timeseries",
-                "title": "CPU Temperature",
-                "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
-                "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                "fieldConfig": {
-                    "defaults": {
-                        "unit": "celsius",
-                        "color": { "mode": "palette-classic" },
-                        "custom": {
-                            "lineWidth": 1,
-                            "fillOpacity": 20,
-                            "gradientMode": "scheme",
-                            "axisLabel": "",
-                            "showPoints": "never",
-                            "thresholdsStyle": { "mode": "line+area" }
-                        },
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                { "color": "transparent", "value": null },
-                                { "color": "red", "value": 70 }
-                            ]
-                        }
-                    },
-                    "overrides": []
-                },
-                "options": {
-                    "legend": { "displayMode": "list", "placement": "bottom" },
-                    "tooltip": { "mode": "multi", "sort": "desc" }
-                },
-                "targets": [
-                    {
-                        "refId": "A",
-                        "alias": "CPU Temp",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT mean(\"value\") / 1000 FROM \"cpu_temperature\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
-                        "rawQuery": true,
-                        "resultFormat": "time_series"
-                    }
-                ]
-            },
-            {
-                "id": 12,
-                "type": "timeseries",
-                "title": "RAM & Swap Usage",
-                "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
-                "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                "fieldConfig": {
-                    "defaults": {
-                        "unit": "percent",
-                        "min": 0,
-                        "max": 100,
-                        "color": { "mode": "palette-classic" },
-                        "custom": {
-                            "lineWidth": 1,
-                            "fillOpacity": 20,
-                            "gradientMode": "scheme",
-                            "axisLabel": "",
-                            "showPoints": "never",
-                            "thresholdsStyle": { "mode": "off" }
-                        }
-                    },
-                    "overrides": [
-                        {
-                            "matcher": { "id": "byName", "options": "RAM" },
-                            "properties": [
-                                {
-                                    "id": "thresholds",
-                                    "value": {
-                                        "mode": "absolute",
-                                        "steps": [
-                                            { "color": "transparent", "value": null },
-                                            { "color": "red", "value": 85 }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "id": "custom.thresholdsStyle",
-                                    "value": { "mode": "line" }
-                                }
-                            ]
-                        },
-                        {
-                            "matcher": { "id": "byName", "options": "Swap" },
-                            "properties": [
-                                {
-                                    "id": "custom.lineStyle",
-                                    "value": { "fill": "dash", "dash": [10, 10] }
-                                }
-                            ]
-                        }
-                    ]
-                },
-                "options": {
-                    "legend": { "displayMode": "list", "placement": "bottom" },
-                    "tooltip": { "mode": "multi", "sort": "desc" }
-                },
-                "targets": [
-                    {
-                        "refId": "A",
-                        "alias": "RAM",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT mean(\"used_percent\") FROM \"mem\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
-                        "rawQuery": true,
-                        "resultFormat": "time_series"
-                    },
-                    {
-                        "refId": "B",
-                        "alias": "Swap",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT mean(\"used_percent\") FROM \"swap\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
-                        "rawQuery": true,
-                        "resultFormat": "time_series"
-                    }
-                ]
-            },
-            {
-                "id": 13,
-                "type": "timeseries",
-                "title": "Disk Usage /",
-                "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
-                "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                "fieldConfig": {
-                    "defaults": {
-                        "unit": "percent",
-                        "min": 0,
-                        "max": 100,
-                        "color": { "mode": "palette-classic" },
-                        "custom": {
-                            "lineWidth": 1,
-                            "fillOpacity": 20,
-                            "gradientMode": "scheme",
-                            "axisLabel": "",
-                            "showPoints": "never",
-                            "thresholdsStyle": { "mode": "line+area" }
-                        },
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                { "color": "transparent", "value": null },
-                                { "color": "red", "value": 85 }
-                            ]
-                        }
-                    },
-                    "overrides": []
-                },
-                "options": {
-                    "legend": { "displayMode": "list", "placement": "bottom" },
-                    "tooltip": { "mode": "multi", "sort": "desc" }
-                },
-                "targets": [
-                    {
-                        "refId": "A",
-                        "alias": "Disk /",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT mean(\"used_percent\") FROM \"disk\" WHERE (\"path\" = '/') AND $timeFilter GROUP BY time($__interval) fill(none)",
-                        "rawQuery": true,
-                        "resultFormat": "time_series"
-                    }
-                ]
-            },
-            {
-                "id": 14,
-                "type": "timeseries",
-                "title": "Load Average",
-                "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
-                "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                "fieldConfig": {
-                    "defaults": {
-                        "min": 0,
-                        "color": { "mode": "palette-classic" },
-                        "custom": {
-                            "lineWidth": 1,
-                            "fillOpacity": 10,
-                            "gradientMode": "scheme",
-                            "axisLabel": "",
-                            "showPoints": "never",
-                            "thresholdsStyle": { "mode": "line+area" }
-                        },
-                        "thresholds": {
-                            "mode": "absolute",
-                            "steps": [
-                                { "color": "transparent", "value": null },
-                                { "color": "red", "value": 4 }
-                            ]
-                        }
-                    },
-                    "overrides": []
-                },
-                "options": {
-                    "legend": { "displayMode": "list", "placement": "bottom" },
-                    "tooltip": { "mode": "multi", "sort": "desc" }
-                },
-                "targets": [
-                    {
-                        "refId": "A",
-                        "alias": "Load 1m",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT mean(\"load1\") FROM \"system\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
-                        "rawQuery": true,
-                        "resultFormat": "time_series"
-                    },
-                    {
-                        "refId": "B",
-                        "alias": "Load 5m",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT mean(\"load5\") FROM \"system\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
-                        "rawQuery": true,
-                        "resultFormat": "time_series"
-                    },
-                    {
-                        "refId": "C",
-                        "alias": "Load 15m",
-                        "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
-                        "query": "SELECT mean(\"load15\") FROM \"system\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
-                        "rawQuery": true,
-                        "resultFormat": "time_series"
-                    }
-                ]
-            },
-            {
-                "id": 15,
-                "type": "alertlist",
-                "title": "Alert History",
-                "gridPos": { "h": 8, "w": 12, "x": 12, "y": 20 },
-                "options": {
-                    "showOptions": "changes",
-                    "maxItems": 20,
-                    "sortOrder": 1,
-                    "alertName": "",
-                    "dashboardAlerts": false,
-                    "stateFilter": {
-                        "firing": true,
-                        "pending": true,
-                        "noData": true,
-                        "normal": true,
-                        "error": true
-                    },
-                    "folder": { "uid": "ffj796qbttpmoc", "title": "RPi Alerts" }
-                }
-            }
-        ],
-        "schemaVersion": 39
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT 100 - mean(\"usage_idle\") FROM \"cpu\" WHERE (\"cpu\" = 'cpu-total') AND $timeFilter GROUP BY time($__interval) fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ]
     },
-    "folderUid": "ffj796qbttpmoc",
-    "overwrite": true
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "CPU Temp",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "datasource": {
+        "uid": "2QPKy_O4k",
+        "type": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 55
+              },
+              {
+                "color": "orange",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "graphMode": "area",
+        "colorMode": "background",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT mean(\"value\") / 1000 FROM \"cpu_temperature\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "RAM Usage",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
+      "datasource": {
+        "uid": "2QPKy_O4k",
+        "type": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "orange",
+                "value": 85
+              },
+              {
+                "color": "red",
+                "value": 95
+              }
+            ]
+          },
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "options": {
+        "graphMode": "area",
+        "colorMode": "background",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT mean(\"used_percent\") FROM \"mem\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Swap Usage",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "datasource": {
+        "uid": "2QPKy_O4k",
+        "type": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 30
+              },
+              {
+                "color": "orange",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 75
+              }
+            ]
+          },
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "options": {
+        "graphMode": "area",
+        "colorMode": "background",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT mean(\"used_percent\") FROM \"swap\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Disk Usage /",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "datasource": {
+        "uid": "2QPKy_O4k",
+        "type": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "orange",
+                "value": 85
+              },
+              {
+                "color": "red",
+                "value": 95
+              }
+            ]
+          },
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "options": {
+        "graphMode": "area",
+        "colorMode": "background",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT mean(\"used_percent\") FROM \"disk\" WHERE (\"path\" = '/') AND $timeFilter GROUP BY time($__interval) fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "Load Avg (1m)",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "datasource": {
+        "uid": "2QPKy_O4k",
+        "type": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 2
+              },
+              {
+                "color": "orange",
+                "value": 4
+              },
+              {
+                "color": "red",
+                "value": 6
+              }
+            ]
+          },
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "graphMode": "area",
+        "colorMode": "background",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT mean(\"load1\") FROM \"system\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "CPU Usage",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "datasource": {
+        "uid": "2QPKy_O4k",
+        "type": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 20,
+            "gradientMode": "scheme",
+            "axisLabel": "",
+            "showPoints": "never",
+            "thresholdsStyle": {
+              "mode": "line+area"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "alias": "CPU Total",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT 100 - mean(\"usage_idle\") FROM \"cpu\" WHERE (\"cpu\" = 'cpu-total') AND $timeFilter GROUP BY time($__interval) fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "CPU Temperature",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "datasource": {
+        "uid": "2QPKy_O4k",
+        "type": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 20,
+            "gradientMode": "scheme",
+            "axisLabel": "",
+            "showPoints": "never",
+            "thresholdsStyle": {
+              "mode": "line+area"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 70
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "alias": "CPU Temp",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT mean(\"value\") / 1000 FROM \"cpu_temperature\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "RAM & Swap Usage",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "datasource": {
+        "uid": "2QPKy_O4k",
+        "type": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 20,
+            "gradientMode": "scheme",
+            "axisLabel": "",
+            "showPoints": "never",
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RAM"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "transparent",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 85
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.thresholdsStyle",
+                "value": {
+                  "mode": "line"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Swap"
+            },
+            "properties": [
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [
+                    10,
+                    10
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "alias": "RAM",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT mean(\"used_percent\") FROM \"mem\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        },
+        {
+          "refId": "B",
+          "alias": "Swap",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT mean(\"used_percent\") FROM \"swap\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Disk Usage /",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "datasource": {
+        "uid": "2QPKy_O4k",
+        "type": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 20,
+            "gradientMode": "scheme",
+            "axisLabel": "",
+            "showPoints": "never",
+            "thresholdsStyle": {
+              "mode": "line+area"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "alias": "Disk /",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT mean(\"used_percent\") FROM \"disk\" WHERE (\"path\" = '/') AND $timeFilter GROUP BY time($__interval) fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "type": "timeseries",
+      "title": "Load Average",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "datasource": {
+        "uid": "2QPKy_O4k",
+        "type": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "scheme",
+            "axisLabel": "",
+            "showPoints": "never",
+            "thresholdsStyle": {
+              "mode": "line+area"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 4
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "alias": "Load 1m",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT mean(\"load1\") FROM \"system\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        },
+        {
+          "refId": "B",
+          "alias": "Load 5m",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT mean(\"load5\") FROM \"system\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        },
+        {
+          "refId": "C",
+          "alias": "Load 15m",
+          "datasource": {
+            "uid": "2QPKy_O4k",
+            "type": "influxdb"
+          },
+          "query": "SELECT mean(\"load15\") FROM \"system\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ]
+    },
+    {
+      "id": 15,
+      "type": "alertlist",
+      "title": "Alert History",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "options": {
+        "showOptions": "changes",
+        "maxItems": 20,
+        "sortOrder": 1,
+        "alertName": "",
+        "dashboardAlerts": false,
+        "stateFilter": {
+          "firing": true,
+          "pending": true,
+          "noData": true,
+          "normal": true,
+          "error": true
+        },
+        "folder": {
+          "uid": "ffj796qbttpmoc",
+          "title": "RPi Alerts"
+        }
+      }
+    }
+  ],
+  "schemaVersion": 39
 }

--- a/grafana/dashboards/speedtest.json
+++ b/grafana/dashboards/speedtest.json
@@ -1,0 +1,643 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "uid": "influxdb-speedtest",
+        "type": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 6,
+      "interval": "",
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "speedtest",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "ping_latency"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Ping",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "influxdb-speedtest",
+        "type": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 250
+              },
+              {
+                "color": "yellow",
+                "value": 500
+              },
+              {
+                "color": "green",
+                "value": 750
+              },
+              {
+                "color": "blue",
+                "value": 1000
+              }
+            ]
+          },
+          "unit": "Mbits"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "speedtest",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "download_bandwidth"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              },
+              {
+                "params": [
+                  " / 125000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Download",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "influxdb-speedtest",
+        "type": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 250
+              },
+              {
+                "color": "yellow",
+                "value": 500
+              },
+              {
+                "color": "green",
+                "value": 750
+              },
+              {
+                "color": "blue",
+                "value": 1000
+              }
+            ]
+          },
+          "unit": "Mbits"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "speedtest",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "upload_bandwidth"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              },
+              {
+                "params": [
+                  " / 125000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Upload",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {
+        "download": "blue",
+        "speedtest.mean": "blue",
+        "upload": "purple"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "influxdb-speedtest",
+        "type": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "Mbits"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 5,
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": true,
+        "min": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pluginVersion": "7.1.5",
+      "pointradius": 2,
+      "points": true,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "download",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "speedtest",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "download_bandwidth"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              },
+              {
+                "params": [
+                  " / 125000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "alias": "upload",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "speedtest",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "upload_bandwidth"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              },
+              {
+                "params": [
+                  " / 125000"
+                ],
+                "type": "math"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "fill": false,
+          "line": true,
+          "op": "lt",
+          "value": 250,
+          "yaxis": "left"
+        }
+      ],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Bandwidth",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "Mbits",
+          "label": "bandwidth",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": "ping",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "ping": "yellow"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "influxdb-speedtest",
+        "type": "influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 5,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "hiddenSeries": false,
+      "id": 8,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": true,
+        "min": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pluginVersion": "7.1.5",
+      "pointradius": 2,
+      "points": true,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "ping",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "speedtest",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "ping_latency"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Ping",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": "latency",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 26,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "Internet Speedtest",
+  "uid": "speedtest-dashboard",
+  "version": 38
+}

--- a/grafana/dashboards/system-metrics.json
+++ b/grafana/dashboards/system-metrics.json
@@ -1,0 +1,420 @@
+{
+  "uid": "system-metrics-dashboard",
+  "title": "System Metrics",
+  "tags": ["system", "telegraf", "rpi"],
+  "timezone": "browser",
+  "refresh": "30s",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Uptime",
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 0 },
+      "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 3600 },
+              { "color": "green", "value": 86400 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
+          "query": "SELECT last(\"uptime\") FROM \"system\" WHERE $timeFilter",
+          "rawQuery": true,
+          "resultFormat": "table"
+        }
+      ],
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "none" }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "CPU Cores",
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 0 },
+      "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
+      "fieldConfig": { "defaults": { "unit": "none" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
+          "query": "SELECT last(\"n_cpus\") FROM \"system\" WHERE $timeFilter",
+          "rawQuery": true,
+          "resultFormat": "table"
+        }
+      ],
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "none" }
+    },
+    {
+      "id": 3,
+      "type": "gauge",
+      "title": "CPU Usage",
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 0 },
+      "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 60 },
+              { "color": "orange", "value": 80 },
+              { "color": "red", "value": 90 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
+          "query": "SELECT 100 - last(\"usage_idle\") AS \"cpu_usage\" FROM \"cpu\" WHERE \"cpu\" = 'cpu-total' AND $timeFilter",
+          "rawQuery": true,
+          "resultFormat": "table"
+        }
+      ],
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "id": 4,
+      "type": "gauge",
+      "title": "Memory Usage",
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 0 },
+      "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 60 },
+              { "color": "orange", "value": 80 },
+              { "color": "red", "value": 90 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
+          "query": "SELECT last(\"used_percent\") FROM \"mem\" WHERE $timeFilter",
+          "rawQuery": true,
+          "resultFormat": "table"
+        }
+      ],
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "id": 5,
+      "type": "gauge",
+      "title": "Disk Usage /",
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 0 },
+      "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 70 },
+              { "color": "orange", "value": 85 },
+              { "color": "red", "value": 95 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
+          "query": "SELECT last(\"used_percent\") FROM \"disk\" WHERE \"path\" = '/' AND $timeFilter",
+          "rawQuery": true,
+          "resultFormat": "table"
+        }
+      ],
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "id": 6,
+      "type": "gauge",
+      "title": "CPU Temperature",
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 0 },
+      "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 60 },
+              { "color": "orange", "value": 70 },
+              { "color": "red", "value": 80 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
+          "query": "SELECT last(\"value\") / 1000 AS \"temp\" FROM \"cpu_temperature\" WHERE $timeFilter",
+          "rawQuery": true,
+          "resultFormat": "table"
+        }
+      ],
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "CPU Usage %",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "custom": { "fillOpacity": 20, "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
+          "query": "SELECT mean(\"usage_user\") AS \"user\", mean(\"usage_system\") AS \"system\", mean(\"usage_iowait\") AS \"iowait\", mean(\"usage_irq\") + mean(\"usage_softirq\") AS \"irq\" FROM \"cpu\" WHERE \"cpu\" = 'cpu-total' AND $timeFilter GROUP BY time($__interval) fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ],
+      "options": { "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "System Load",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "custom": { "fillOpacity": 10, "lineWidth": 2 }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
+          "query": "SELECT mean(\"load1\") AS \"1m\", mean(\"load5\") AS \"5m\", mean(\"load15\") AS \"15m\" FROM \"system\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ],
+      "options": { "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 20,
+      "type": "timeseries",
+      "title": "Memory",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": { "fillOpacity": 30, "lineWidth": 1, "stacking": { "mode": "normal" } }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "available" },
+            "properties": [{ "id": "custom.fillOpacity", "value": 5 }, { "id": "custom.stacking", "value": { "mode": "none" } }, { "id": "custom.lineStyle", "value": { "fill": "dash", "dash": [10, 10] } }]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
+          "query": "SELECT mean(\"used\") AS \"used\", mean(\"cached\") AS \"cached\", mean(\"buffered\") AS \"buffered\", mean(\"available\") AS \"available\" FROM \"mem\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ],
+      "options": { "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "Swap",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": { "fillOpacity": 20, "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
+          "query": "SELECT mean(\"used\") AS \"used\", mean(\"free\") AS \"free\" FROM \"swap\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ],
+      "options": { "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 30,
+      "type": "timeseries",
+      "title": "Disk I/O (bytes/s)",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
+      "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "custom": { "fillOpacity": 15, "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
+          "query": "SELECT non_negative_derivative(mean(\"read_bytes\"), 1s) AS \"read\", non_negative_derivative(mean(\"write_bytes\"), 1s) AS \"write\" FROM \"diskio\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ],
+      "options": { "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 31,
+      "type": "timeseries",
+      "title": "Network Traffic (bytes/s)",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 20 },
+      "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "custom": { "fillOpacity": 15, "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
+          "query": "SELECT non_negative_derivative(mean(\"bytes_recv\"), 1s) AS \"rx\", non_negative_derivative(mean(\"bytes_sent\"), 1s) AS \"tx\" FROM \"net\" WHERE \"interface\" != 'lo' AND $timeFilter GROUP BY time($__interval) fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ],
+      "options": { "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 40,
+      "type": "timeseries",
+      "title": "CPU Temperature",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 28 },
+      "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius",
+          "custom": { "fillOpacity": 10, "lineWidth": 2 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 60 },
+              { "color": "orange", "value": 70 },
+              { "color": "red", "value": 80 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
+          "query": "SELECT mean(\"value\") / 1000 AS \"temperature\" FROM \"cpu_temperature\" WHERE $timeFilter GROUP BY time($__interval) fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ],
+      "options": { "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 41,
+      "type": "timeseries",
+      "title": "Disk Usage %",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 28 },
+      "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "custom": { "fillOpacity": 10, "lineWidth": 2 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 70 },
+              { "color": "orange", "value": 85 },
+              { "color": "red", "value": 95 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "uid": "2QPKy_O4k", "type": "influxdb" },
+          "query": "SELECT mean(\"used_percent\") FROM \"disk\" WHERE $timeFilter GROUP BY time($__interval), \"path\" fill(none)",
+          "rawQuery": true,
+          "resultFormat": "time_series"
+        }
+      ],
+      "options": { "tooltip": { "mode": "multi" } }
+    }
+  ],
+  "schemaVersion": 39,
+  "version": 1
+}

--- a/grafana/provisioning/dashboards/dashboards.yml
+++ b/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: default
+    orgId: 1
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/grafana/provisioning/datasources/influxdb.yml
+++ b/grafana/provisioning/datasources/influxdb.yml
@@ -1,0 +1,26 @@
+apiVersion: 1
+
+datasources:
+  - name: InfluxDB
+    type: influxdb
+    uid: 2QPKy_O4k
+    access: proxy
+    url: http://influxdb:8086
+    database: telegraf
+    user: ${INFLUXDB_USER}
+    secureJsonData:
+      password: ${INFLUXDB_USER_PASSWORD}
+    isDefault: true
+    editable: false
+
+  - name: InfluxDB-Speedtest
+    type: influxdb
+    uid: influxdb-speedtest
+    access: proxy
+    url: http://influxdb:8086
+    database: speedtest
+    user: ${INFLUXDB_USER}
+    secureJsonData:
+      password: ${INFLUXDB_USER_PASSWORD}
+    isDefault: false
+    editable: false

--- a/scripts/test-sim-stack.sh
+++ b/scripts/test-sim-stack.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# Smoke tests for the RPi4 simulation stack.
+# Validates that the sim environment is functional after boot.
+#
+# Designed to run:
+#   - Locally after `just sim-up`
+#   - In CI (GitHub Actions nightly workflow)
+#
+# Prerequisites: sim stack running, jq + curl available.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="$PROJECT_DIR/sim/.env.sim"
+
+# Read credentials from sim/.env.sim
+_read_env() { grep "^$1=" "$ENV_FILE" | cut -d= -f2- | sed "s/^['\"]//;s/['\"]$//"; }
+
+_user=$(_read_env GF_SECURITY_ADMIN_USER)
+_pass=$(_read_env GF_SECURITY_ADMIN_PASSWORD)
+_influx_admin=$(_read_env INFLUXDB_ADMIN_USER)
+_influx_admin_pass=$(_read_env INFLUXDB_ADMIN_PASSWORD)
+
+GRAFANA_URL="http://localhost:3000"
+GRAFANA_CREDS="${_user:-admin}:${_pass}"
+# Helper: pass creds via process substitution (not visible in /proc cmdline)
+_gcurl() { curl -sf -K <(printf 'user = "%s"\n' "$GRAFANA_CREDS") "$@"; }
+CHRONOGRAF_URL="http://localhost:8888"
+INFLUXDB_URL="http://localhost:8086"
+INFLUXDB_CONTAINER="influxdb"
+
+PASS=0
+FAIL=0
+WARN=0
+
+pass() {
+    echo "  ✅ $1"
+    ((PASS++))
+}
+fail() {
+    echo "  ❌ $1"
+    ((FAIL++))
+}
+warn() {
+    echo "  ⚠️  $1"
+    ((WARN++))
+}
+
+influx_query() {
+    docker exec "$INFLUXDB_CONTAINER" influx \
+        -username "${_influx_admin:-admin}" \
+        -password "${_influx_admin_pass}" \
+        -execute "$1" -database "${2:-}" 2>/dev/null
+}
+
+check_dashboard() {
+    local uid="$1" name="$2"
+    if _gcurl "$GRAFANA_URL/api/dashboards/uid/$uid" 2>/dev/null | jq -e '.dashboard' >/dev/null 2>&1; then
+        pass "Dashboard '$name' (uid=$uid)"
+    else
+        fail "Dashboard '$name' missing (uid=$uid)"
+    fi
+}
+
+echo "╔══════════════════════════════════════════════════════════╗"
+echo "║     Sim Stack — E2E Smoke Tests                         ║"
+echo "║     $(date -Iseconds)                      ║"
+echo "╚══════════════════════════════════════════════════════════╝"
+echo ""
+
+# ── 1. Service Health ─────────────────────────────────────────
+echo "── 1. Service Health ──"
+
+if curl -sf "$GRAFANA_URL/api/health" | jq -e '.database == "ok"' >/dev/null 2>&1; then
+    pass "Grafana responds on :3000"
+else
+    fail "Grafana not responding on :3000"
+fi
+
+if influx_query "SHOW DATABASES" | grep -q speedtest; then
+    pass "InfluxDB responds (speedtest DB exists)"
+else
+    fail "InfluxDB not responding or speedtest DB missing"
+fi
+
+if curl -sf "$CHRONOGRAF_URL/chronograf/v1/me" >/dev/null 2>&1; then
+    pass "Chronograf responds on :8888"
+else
+    fail "Chronograf not responding on :8888"
+fi
+
+echo ""
+
+# ── 2. Grafana Datasources ───────────────────────────────────
+echo "── 2. Grafana Datasources ──"
+
+DS_JSON=$(_gcurl "$GRAFANA_URL/api/datasources" 2>/dev/null || echo "[]")
+DS_COUNT=$(echo "$DS_JSON" | jq length 2>/dev/null || echo 0)
+if [[ "$DS_COUNT" -eq 2 ]]; then
+    pass "Grafana has 2 datasources"
+else
+    fail "Grafana datasources: expected 2, got $DS_COUNT"
+fi
+
+for ds_name in "InfluxDB" "InfluxDB-Speedtest"; do
+    if echo "$DS_JSON" | jq -e --arg n "$ds_name" '.[] | select(.name == $n)' >/dev/null 2>&1; then
+        pass "Datasource '$ds_name' exists"
+    else
+        fail "Datasource '$ds_name' missing"
+    fi
+done
+
+for ds_uid in $(echo "$DS_JSON" | jq -r '.[].uid' 2>/dev/null); do
+    ds_name=$(echo "$DS_JSON" | jq -r --arg uid "$ds_uid" '.[] | select(.uid == $uid) | .name')
+    if _gcurl -X POST "$GRAFANA_URL/api/datasources/uid/$ds_uid/health" 2>/dev/null | jq -e '.status == "OK"' >/dev/null 2>&1; then
+        pass "Datasource '$ds_name' connectivity OK"
+    else
+        fail "Datasource '$ds_name' cannot connect to InfluxDB"
+    fi
+done
+
+echo ""
+
+# ── 3. Grafana Dashboards ────────────────────────────────────
+echo "── 3. Grafana Dashboards ──"
+
+check_dashboard "speedtest-dashboard" "Internet Speedtest"
+check_dashboard "rpi-docker-dashboard" "Docker Containers"
+check_dashboard "rpi-alerts-dashboard" "RPi Alerts Overview"
+check_dashboard "system-metrics-dashboard" "System Metrics"
+
+echo ""
+
+# ── 4. InfluxDB Schema ───────────────────────────────────────
+echo "── 4. InfluxDB Schema ──"
+
+for db in speedtest telegraf; do
+    if influx_query "SHOW DATABASES" | grep -q "^${db}$"; then
+        pass "Database '$db' exists"
+    else
+        fail "Database '$db' missing"
+    fi
+done
+
+GRANTS=$(influx_query "SHOW GRANTS FOR \"telegraf\"" 2>/dev/null)
+for db in speedtest telegraf; do
+    if echo "$GRANTS" | grep -q "$db.*ALL"; then
+        pass "User 'telegraf' has ALL on '$db'"
+    else
+        fail "User 'telegraf' missing privileges on '$db'"
+    fi
+done
+
+echo ""
+
+# ── 5. Telegraf Pipeline ─────────────────────────────────────
+echo "── 5. Telegraf Pipeline ──"
+
+TELEGRAF_COUNT=$(influx_query "SELECT COUNT(usage_idle) FROM cpu WHERE time > now() - 5m" telegraf 2>/dev/null | tail -1 | awk '{print $2}')
+if [[ -n "$TELEGRAF_COUNT" && "$TELEGRAF_COUNT" =~ ^[0-9]+$ && "$TELEGRAF_COUNT" -gt 0 ]]; then
+    pass "Telegraf → InfluxDB pipeline active ($TELEGRAF_COUNT cpu points in last 5 min)"
+else
+    fail "Telegraf → InfluxDB pipeline broken (0 cpu points in last 5 min)"
+fi
+
+echo ""
+
+# ── 6. Speedtest Write Path ──────────────────────────────────
+echo "── 6. Speedtest Write Path ──"
+
+# Inject a synthetic data point to validate the write path
+# without running a real speedtest (avoids network dependency + QEMU slowness).
+INJECT_RESULT=$(curl -sf -o /dev/null -w "%{http_code}" -XPOST \
+    "${INFLUXDB_URL}/write?db=speedtest&u=${_influx_admin}&p=${_influx_admin_pass}" \
+    --data-binary 'speedtest,result_id=ci-smoke-test ping_latency=10.5,download_bandwidth=1000000.0,upload_bandwidth=500000.0')
+if [[ "$INJECT_RESULT" == "204" ]]; then
+    pass "Speedtest write path works (injected test point)"
+else
+    fail "Speedtest write path broken (HTTP $INJECT_RESULT)"
+fi
+
+# Verify the injected point is queryable
+QUERY_COUNT=$(influx_query "SELECT COUNT(download_bandwidth) FROM speedtest WHERE \"result_id\" = 'ci-smoke-test'" speedtest 2>/dev/null | tail -1 | awk '{print $2}')
+if [[ -n "$QUERY_COUNT" && "$QUERY_COUNT" =~ ^[0-9]+$ && "$QUERY_COUNT" -ge 1 ]]; then
+    pass "Injected test point is queryable ($QUERY_COUNT point(s))"
+else
+    fail "Injected test point not found in query results"
+fi
+
+# Clean up: remove synthetic data
+influx_query "DELETE FROM speedtest WHERE \"result_id\" = 'ci-smoke-test'" speedtest >/dev/null 2>&1
+
+echo ""
+
+# ── 7. Container State ───────────────────────────────────────
+echo "── 7. Container State ──"
+
+for svc in grafana influxdb chronograf telegraf docker-socket-proxy speedtest-cron; do
+    if docker ps --format '{{.Names}}' 2>/dev/null | grep -qi "$svc"; then
+        pass "Container '$svc' running"
+    else
+        fail "Container '$svc' not running"
+    fi
+done
+
+echo ""
+
+# ── Summary ───────────────────────────────────────────────────
+echo "╔══════════════════════════════════════════════════════════╗"
+printf "║  Results: ✅ %-3d passed  ❌ %-3d failed  ⚠️  %-3d warnings ║\n" "$PASS" "$FAIL" "$WARN"
+echo "╚══════════════════════════════════════════════════════════╝"
+
+[[ "$FAIL" -eq 0 ]] && exit 0 || exit 1

--- a/sim/.env.sim
+++ b/sim/.env.sim
@@ -1,0 +1,8 @@
+# Simulation environment — safe defaults for local dev
+# Copy to .env if not already present, or source via docker compose --env-file
+GF_SECURITY_ADMIN_USER=admin
+GF_SECURITY_ADMIN_PASSWORD=simpass
+INFLUXDB_ADMIN_USER=admin
+INFLUXDB_ADMIN_PASSWORD=simpass
+INFLUXDB_USER=telegraf
+INFLUXDB_USER_PASSWORD=simpass

--- a/sim/docker-compose.sim.yml
+++ b/sim/docker-compose.sim.yml
@@ -77,3 +77,33 @@ services:
       dockerfile: Dockerfile
       platforms:
         - linux/arm64
+
+  # Periodic speedtest — replaces the systemd timer from production.
+  # Runs every SPEEDTEST_INTERVAL seconds (default 600 = 10 min).
+  speedtest-cron:
+    container_name: speedtest-cron
+    build:
+      context: .
+      dockerfile: Dockerfile
+      platforms:
+        - linux/arm64
+    platform: linux/arm64
+    mem_limit: 256m
+    memswap_limit: 384m
+    environment:
+      INFLUXDB_USER: ${INFLUXDB_USER}
+      INFLUXDB_USER_PASSWORD: ${INFLUXDB_USER_PASSWORD}
+      SPEEDTEST_INTERVAL: '600'
+    networks:
+      - speedtest
+    depends_on:
+      influxdb:
+        condition: service_healthy
+    volumes:
+      - ./sim/speedtest-loop.sh:/usr/local/bin/speedtest-loop.sh:ro
+    entrypoint: ['/bin/bash', '/usr/local/bin/speedtest-loop.sh']
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL

--- a/sim/docker-compose.sim.yml
+++ b/sim/docker-compose.sim.yml
@@ -1,0 +1,79 @@
+# docker-compose.sim.yml — RPi4 ARM64 simulation on x86 host
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f sim/docker-compose.sim.yml up -d
+#
+# What this does:
+#   - Forces linux/arm64 platform on all services (QEMU user-mode emulation)
+#   - Swaps Telegraf config for x86-compatible version
+#   - Adds memory limits matching RPi4 constraints (4 Go total budget)
+#   - Uses separate project name & volumes to avoid conflicts with production
+#   - Exposes InfluxDB port for external tooling (CQ migration, etc.)
+
+services:
+  grafana:
+    platform: linux/arm64
+    mem_limit: 512m
+    memswap_limit: 768m
+
+  influxdb:
+    platform: linux/arm64
+    mem_limit: 1g
+    memswap_limit: 1536m
+    # InfluxDB 1.8 entrypoint needs these caps to init data dir (chown/mkdir)
+    # They are dropped by cap_drop: ALL in the base compose
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - SETUID
+      - SETGID
+      - FOWNER
+    # QEMU emulation is ~10x slower — increase healthcheck timeouts
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          influx
+          -username "$INFLUXDB_ADMIN_USER"
+          -password "$INFLUXDB_ADMIN_PASSWORD"
+          -execute 'SHOW DATABASES'
+          >/dev/null 2>&1 || exit 1
+      interval: 30s
+      timeout: 30s
+      retries: 10
+      start_period: 120s
+    # Expose InfluxDB for external access (CQ migration from laptop, etc.)
+    ports:
+      - '127.0.0.1:8086:8086'
+    environment:
+      # R4: disable _internal for RPi simulation
+      INFLUXDB_MONITOR_STORE_ENABLED: 'false'
+
+  chronograf:
+    platform: linux/arm64
+    mem_limit: 256m
+    memswap_limit: 384m
+
+  docker-socket-proxy:
+    platform: linux/arm64
+    mem_limit: 64m
+    memswap_limit: 64m
+
+  telegraf:
+    platform: linux/arm64
+    mem_limit: 256m
+    memswap_limit: 384m
+    hostname: rpi-sim
+    volumes:
+      - ./sim/telegraf-sim.conf:/etc/telegraf/telegraf.conf:ro
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /var/run/utmp:/var/run/utmp:ro
+
+  speedtest:
+    platform: linux/arm64
+    build:
+      context: .
+      dockerfile: Dockerfile
+      platforms:
+        - linux/arm64

--- a/sim/docker-compose.sim.yml
+++ b/sim/docker-compose.sim.yml
@@ -45,6 +45,9 @@ services:
     # Expose InfluxDB for external access (CQ migration from laptop, etc.)
     ports:
       - '127.0.0.1:8086:8086'
+    volumes:
+      # Init script creates databases + grants on first boot (empty volume)
+      - ./sim/influxdb-init.iql:/docker-entrypoint-initdb.d/init.iql:ro
     environment:
       # R4: disable _internal for RPi simulation
       INFLUXDB_MONITOR_STORE_ENABLED: 'false'
@@ -77,6 +80,9 @@ services:
       dockerfile: Dockerfile
       platforms:
         - linux/arm64
+    environment:
+      INFLUXDB_USER: ${INFLUXDB_ADMIN_USER:-admin}
+      INFLUXDB_USER_PASSWORD: ${INFLUXDB_ADMIN_PASSWORD}
 
   # Periodic speedtest — replaces the systemd timer from production.
   # Runs every SPEEDTEST_INTERVAL seconds (default 600 = 10 min).
@@ -91,8 +97,8 @@ services:
     mem_limit: 256m
     memswap_limit: 384m
     environment:
-      INFLUXDB_USER: ${INFLUXDB_USER}
-      INFLUXDB_USER_PASSWORD: ${INFLUXDB_USER_PASSWORD}
+      INFLUXDB_USER: ${INFLUXDB_ADMIN_USER:-admin}
+      INFLUXDB_USER_PASSWORD: ${INFLUXDB_ADMIN_PASSWORD}
       SPEEDTEST_INTERVAL: '600'
     networks:
       - speedtest

--- a/sim/influxdb-init.iql
+++ b/sim/influxdb-init.iql
@@ -1,0 +1,6 @@
+-- InfluxDB init script — runs once on first container boot (empty volume).
+-- Creates both databases and grants the non-admin user full access.
+CREATE DATABASE telegraf
+CREATE DATABASE speedtest
+GRANT ALL ON telegraf TO "telegraf"
+GRANT ALL ON speedtest TO "telegraf"

--- a/sim/speedtest-loop.sh
+++ b/sim/speedtest-loop.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Periodically run speedtest, mimicking the systemd timer in production.
+# Default interval: 600s (10 min), matching speedtest.timer OnCalendar=*:0/10.
+
+interval="${SPEEDTEST_INTERVAL:-600}"
+
+echo "Speedtest cron started (interval: ${interval}s)"
+
+while true; do
+    echo "[$(date -Iseconds)] Running speedtest..."
+    timeout --preserve-status --signal=SIGTERM "${TIME_CHECK:-180}" \
+        /usr/local/bin/docker-entrypoint.sh &&
+        echo "[$(date -Iseconds)] OK" ||
+        echo "[$(date -Iseconds)] Failed (exit $?)"
+    echo "[$(date -Iseconds)] Next run in ${interval}s"
+    sleep "$interval"
+done

--- a/sim/speedtest-loop.sh
+++ b/sim/speedtest-loop.sh
@@ -6,6 +6,11 @@ set -euo pipefail
 
 interval="${SPEEDTEST_INTERVAL:-600}"
 
+# Trap SIGTERM so docker stop doesn't wait for the full stop timeout.
+# Kill the sleep process (if running) and exit cleanly.
+sleep_pid=
+trap 'echo "[$(date -Iseconds)] Shutting down"; [[ -n "$sleep_pid" ]] && kill "$sleep_pid" 2>/dev/null; exit 0' SIGTERM SIGINT
+
 echo "Speedtest cron started (interval: ${interval}s)"
 
 while true; do
@@ -15,5 +20,8 @@ while true; do
         echo "[$(date -Iseconds)] OK" ||
         echo "[$(date -Iseconds)] Failed (exit $?)"
     echo "[$(date -Iseconds)] Next run in ${interval}s"
-    sleep "$interval"
+    sleep "$interval" &
+    sleep_pid=$!
+    wait "$sleep_pid" || true
+    sleep_pid=
 done

--- a/sim/telegraf-sim.conf
+++ b/sim/telegraf-sim.conf
@@ -1,0 +1,85 @@
+# Telegraf Configuration — RPi4 Simulation (x86 host)
+# Adapted from telegraf/telegraf.conf for local dev without a real RPi.
+# Differences from production:
+#   - cpu_temperature reads thermal_zone0 (x86 CPU, not BCM2711)
+#   - net interfaces: wildcard (auto-detect) instead of eth0/wlan0
+#   - Docker input uses same socket-proxy pattern
+
+[global_tags]
+  env = "sim"
+
+[agent]
+  interval = "20s"
+  round_interval = true
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  collection_jitter = "0s"
+  flush_interval = "10s"
+  flush_jitter = "0s"
+  precision = ""
+  debug = false
+  quiet = false
+  hostname = "rpi-sim"
+  omit_hostname = false
+
+# ── Output: InfluxDB ──────────────────────────────────────────
+
+[[outputs.influxdb]]
+  urls = ["http://influxdb:8086"]
+  database = "telegraf"
+  skip_database_creation = true
+  retention_policy = ""
+  write_consistency = "any"
+  timeout = "5s"
+  username = "${INFLUXDB_USER}"
+  password = "${INFLUXDB_USER_PASSWORD}"
+  user_agent = "telegraf"
+
+# ── Inputs: System Metrics ────────────────────────────────────
+
+# CPU temperature — x86 thermal zone (produces same measurement name)
+[[inputs.file]]
+  files = ["/host/sys/class/thermal/thermal_zone0/temp"]
+  name_override = "cpu_temperature"
+  data_format = "value"
+  data_type = "integer"
+
+[[inputs.cpu]]
+  percpu = true
+  totalcpu = true
+  fielddrop = ["time_*"]
+
+[[inputs.disk]]
+  ignore_fs = ["tmpfs", "devtmpfs"]
+
+[[inputs.diskio]]
+
+[[inputs.kernel]]
+
+[[inputs.mem]]
+
+[[inputs.processes]]
+
+[[inputs.swap]]
+
+[[inputs.system]]
+
+# Net — wildcard: collect all real interfaces (no eth0/wlan0 on x86)
+[[inputs.net]]
+
+[[inputs.netstat]]
+
+[[inputs.interrupts]]
+
+[[inputs.linux_sysctl_fs]]
+
+# ── Inputs: Docker Containers ─────────────────────────────────
+
+[[inputs.docker]]
+  endpoint = "tcp://docker-socket-proxy:2375"
+  gather_services = false
+  container_name_include = []
+  container_name_exclude = []
+  timeout = "5s"
+  perdevice_include = []
+  total_include = ["cpu", "blkio", "network"]


### PR DESCRIPTION
## Summary

Full RPi4 simulation environment running ARM64 containers via QEMU on x86_64.
Validates the entire monitoring stack (InfluxDB, Grafana, Telegraf, Chronograf,
Speedtest) in near-production conditions without needing the physical Raspberry Pi.

## What's included

### Simulation stack (`sim/`)
- **Compose overlay** (`sim/docker-compose.sim.yml`): forces `linux/arm64` on all
  services, adds memory limits matching RPi4 4 GB budget, QEMU-adapted healthchecks
- **Telegraf sim config** (`sim/telegraf-sim.conf`): x86-compatible inputs
  (thermal_zone0, wildcard net interfaces)
- **Speedtest cron** (`sim/speedtest-loop.sh`): replaces systemd timer with a
  container-based loop (SIGTERM-aware for graceful shutdown)
- **InfluxDB init script** (`sim/influxdb-init.iql`): creates databases + grants
  on first boot

### Grafana provisioning (`grafana/provisioning/`)
- Datasources as code: `InfluxDB` (telegraf) + `InfluxDB-Speedtest` (speedtest)
- Dashboard provider: auto-loads JSON from `grafana/dashboards/`
- 4 provisioned dashboards: Docker Containers, RPi Alerts, Internet Speedtest,
  System Metrics

### Smoke tests & CI
- **`scripts/test-sim-stack.sh`**: 25-check suite across 7 sections (service health,
  datasources, dashboards, schema, Telegraf pipeline, speedtest write path, containers)
- **`.github/workflows/sim-e2e-nightly.yml`**: nightly at 03:30 UTC +
  `workflow_dispatch` for manual PR validation
- Pipeline: `binfmt → build → up → wait → smoke tests → teardown` (~12-15 min)

### Justfile recipes (12 new `sim-*` recipes)
`sim-up`, `sim-stop`, `sim-down`, `sim-nuke`, `sim-status`, `sim-logs`,
`sim-logs-follow`, `sim-build`, `sim-speedtest`, `sim-influx-shell`, `sim-stats`,
`sim-test`, `sim-binfmt`

### Documentation
- `docs/sim-environment.md`: architecture, overlay changes, memory budget, Grafana
  provisioning, Telegraf config, fidelity analysis (sim vs prod), troubleshooting,
  CI/CD section
- `README.md`: new Simulation RPi4 section, sim-test in Testing table, nightly CI
  mention

### Lint coverage fix
- `sim/*.sh` added to shellcheck/shfmt in both `just lint` and CI `lint.yml`

## Commits (16, SoC)

| Type | Message |
|------|---------|
| feat | add RPi4 ARM64 simulation stack |
| feat | add Grafana provisioning (datasources + dashboards) |
| feat | add provisioned Grafana dashboards |
| feat | add Justfile recipes for sim stack management |
| feat | add periodic speedtest-cron service to sim stack |
| feat | add sim-test recipe and extend lint to sim/*.sh |
| fix | correct container names and shell variable syntax in sim recipes |
| fix | add SIGTERM trap to speedtest-loop for graceful shutdown |
| fix | add InfluxDB init script and use admin creds for speedtest |
| test | add sim stack smoke tests |
| ci | add nightly sim stack e2e workflow |
| ci | add sim/*.sh to shellcheck and shfmt in lint workflow |
| docs | add simulation environment documentation |
| docs | add simulation fidelity analysis (sim vs production RPi) |
| docs | update sim-environment with init script and CI section |
| docs | add sim stack and CI sections to README and docs |

## How to test

```bash
# Register QEMU (once per reboot)
just sim-binfmt

# Start the stack (~2-3 min under QEMU)
just sim-up

# Wait for InfluxDB healthy + Telegraf data (~2 min)
just sim-status

# Run smoke tests
just sim-test

# Or trigger the CI workflow manually:
# Actions → Sim Stack E2E — Nightly → Run workflow
```

## Stats

- **18 files changed**, 3742 insertions, 1054 deletions
- **25 smoke tests** across 7 sections
- **12 new Justfile recipes**