### PR TITLE
feat: Lighthouse audit tooling (CI + local)

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,86 @@
+name: Lighthouse Audit
+
+on:
+  # Run after each gh-pages deploy
+  workflow_run:
+    workflows: ['Deploy GitHub Pages']
+    types: [completed]
+  # Weekly standalone run (Monday 06:00 UTC)
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch: # Manual trigger
+
+permissions:
+  contents: read
+
+jobs:
+  lighthouse:
+    name: Lighthouse (${{ matrix.preset }})
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        preset: [mobile, desktop]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Lighthouse
+        run: npm install -g lighthouse
+
+      - name: Run Lighthouse (${{ matrix.preset }})
+        run: |
+          set -euo pipefail
+          URL="https://yoyonel.github.io/rpi-internet-monitoring/"
+          ARGS=(
+            "$URL"
+            --output html --output json
+            --output-path "./lighthouse-${{ matrix.preset }}"
+            --chrome-flags="--headless --no-sandbox"
+          )
+          if [[ "${{ matrix.preset }}" == "desktop" ]]; then
+            ARGS+=(--preset desktop)
+          fi
+          lighthouse "${ARGS[@]}"
+
+      - name: Extract scores & build summary
+        id: scores
+        run: |
+          set -euo pipefail
+          JSON="./lighthouse-${{ matrix.preset }}.report.json"
+          read_score() {
+            python3 -c "import json; d=json.load(open('$JSON')); \
+              print(int(d['categories']['$1']['score']*100))"
+          }
+          PERF=$(read_score performance)
+          A11Y=$(read_score accessibility)
+          BP=$(read_score best-practices)
+          SEO=$(read_score seo)
+          {
+            echo "perf=$PERF"
+            echo "a11y=$A11Y"
+            echo "bp=$BP"
+            echo "seo=$SEO"
+          } >> "$GITHUB_OUTPUT"
+
+          badge() { if (( $1 >= 90 )); then echo "🟢"; elif (( $1 >= 50 )); then echo "🟠"; else echo "🔴"; fi; }
+          {
+            echo "## Lighthouse — ${{ matrix.preset }}"
+            echo ""
+            echo "| Category | Score |"
+            echo "|----------|------:|"
+            echo "| $(badge "$PERF") Performance   | **${PERF}** |"
+            echo "| $(badge "$A11Y") Accessibility  | **${A11Y}** |"
+            echo "| $(badge "$BP") Best Practices | **${BP}** |"
+            echo "| $(badge "$SEO") SEO            | **${SEO}** |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Lighthouse report
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-${{ matrix.preset }}
+          path: |
+            lighthouse-${{ matrix.preset }}.report.html
+            lighthouse-${{ matrix.preset }}.report.json
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ node_modules/
 test-results/
 playwright-report/
 
+# Lighthouse
+lighthouse-reports/
+
 # Editor
 *.swp
 *~

--- a/Justfile
+++ b/Justfile
@@ -217,6 +217,14 @@ fmt:
 e2e url="http://localhost:8080":
     E2E_BASE_URL={{ url }} npx playwright test
 
+# Run Lighthouse audit on production (mobile+desktop by default, --open to view)
+lighthouse *args="--both":
+    bash scripts/lighthouse.sh {{ args }}
+
+# Parse Lighthouse reports and show prioritized action plan
+lighthouse-report preset="both":
+    python3 scripts/lighthouse-report.py {{ preset }}
+
 # ── RPi4 Simulation (ARM64 on x86) ─────────────────────
 
 sim_compose := "docker compose -f docker-compose.yml -f sim/docker-compose.sim.yml --env-file sim/.env.sim -p rpi-sim"

--- a/README.md
+++ b/README.md
@@ -111,14 +111,16 @@ just install-timers
 
 ### Testing
 
-| Commande         | RPi requis | Description                                             |
-| ---------------- | ---------- | ------------------------------------------------------- |
-| `just test`      | **oui**    | Suite de régression complète (17 checks)                |
-| `just check`     | **oui**    | Health check rapide des 4 services                      |
-| `just e2e [url]` | non        | Tests E2E Playwright contre une preview (défaut: :8080) |
-| `just sim-test`  | non        | Smoke tests de la stack sim (25 checks)                 |
-| `just lint`      | non        | Vérifier le formatage et le linting de tous les sources |
-| `just fmt`       | non        | Auto-formater tous les fichiers sources                 |
+| Commande                     | RPi requis | Description                                                     |
+| ---------------------------- | ---------- | --------------------------------------------------------------- |
+| `just test`                  | **oui**    | Suite de régression complète (17 checks)                        |
+| `just check`                 | **oui**    | Health check rapide des 4 services                              |
+| `just e2e [url]`             | non        | Tests E2E Playwright contre une preview (défaut: :8080)         |
+| `just sim-test`              | non        | Smoke tests de la stack sim (25 checks)                         |
+| `just lint`                  | non        | Vérifier le formatage et le linting de tous les sources         |
+| `just fmt`                   | non        | Auto-formater tous les fichiers sources                         |
+| `just lighthouse [flags]`    | non        | Audit Lighthouse sur la page prod (mobile+desktop par défaut)   |
+| `just lighthouse-report [p]` | non        | Analyse priorisée des rapports Lighthouse (mobile/desktop/both) |
 
 ### Publication & Preview
 
@@ -348,6 +350,19 @@ La CI exécute `just lint` sur chaque push et PR via `.github/workflows/lint.yml
 
 Un workflow dédié (`.github/workflows/sim-e2e-nightly.yml`) démarre la stack ARM64 complète sur un runner Ubuntu chaque nuit (03:30 UTC) et exécute les 25 smoke tests. Déclenchable manuellement via l'onglet **Actions** → **Sim Stack E2E — Nightly** → **Run workflow** pour valider une PR.
 
+#### Lighthouse Audit
+
+Le workflow `.github/workflows/lighthouse.yml` lance des audits Lighthouse **Mobile** et **Desktop** contre la page de production. Il se déclenche :
+
+- **automatiquement** après chaque déploiement GitHub Pages (via `workflow_run`)
+- **hebdomadairement** (lundi 06:00 UTC)
+- **manuellement** (onglet **Actions** → **Lighthouse Audit** → **Run workflow**)
+
+Chaque run produit :
+
+- Un **Job Summary** avec tableau de scores et badges colorés (🟢 ≥90, 🟠 ≥50, 🔴 <50)
+- Les rapports HTML et JSON en artifacts (rétention 30 jours)
+
 ## GitHub Pages — Vue externe
 
 Page statique publique avec les résultats speedtest des 30 derniers jours :
@@ -404,6 +419,31 @@ just preview-dev        # Prévisualiser avec les données live (http://localhos
 ```
 
 `publish-template` est utile quand on modifie le design, les stats, ou les graphiques sans avoir accès au RPi : il récupère les données actuelles de la page live, les injecte dans le template local, et pousse le résultat sur GitHub Pages.
+
+### Audit Lighthouse (local)
+
+Deux commandes pour auditer et analyser les performances de la page de production :
+
+```bash
+just lighthouse              # Lancer les audits Mobile + Desktop
+just lighthouse --mobile     # Mobile seul
+just lighthouse --desktop    # Desktop seul
+just lighthouse --both --open  # Les deux + ouvrir les rapports HTML
+```
+
+```bash
+just lighthouse-report         # Analyse priorisée (mobile + desktop)
+just lighthouse-report mobile  # Mobile seul
+just lighthouse-report desktop # Desktop seul
+```
+
+Le rapport affiche les scores, les quick wins (accessibilité, SEO) et les opportunités de performance classées par priorité (HIGH/MEDIUM/LOW) avec les savings estimés et les ressources impactées.
+
+Les rapports sont stockés dans `lighthouse-reports/` (gitignored) avec des symlinks `latest-*.report.{html,json}` pointant toujours sur le dernier run.
+
+**Prérequis** : `npm install -g lighthouse`
+
+**Workflow typique** : `just lighthouse` → `just lighthouse-report` → corriger → re-auditer.
 
 ### Développement
 

--- a/scripts/lighthouse-report.py
+++ b/scripts/lighthouse-report.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Parse Lighthouse JSON reports and produce a prioritized action plan.
+
+Usage:
+    python3 scripts/lighthouse-report.py [mobile|desktop|both]
+
+Reads from lighthouse-reports/latest-{preset}.report.json (symlinks
+created by scripts/lighthouse.sh).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPORT_DIR = Path(__file__).resolve().parent.parent / "lighthouse-reports"
+
+# ── Colours ──────────────────────────────────────────────
+
+RESET = "\033[0m"
+BOLD = "\033[1m"
+DIM = "\033[2m"
+RED = "\033[91m"
+YELLOW = "\033[93m"
+GREEN = "\033[92m"
+CYAN = "\033[96m"
+MAGENTA = "\033[95m"
+WHITE = "\033[97m"
+BG_RED = "\033[41m"
+BG_YELLOW = "\033[43m"
+BG_GREEN = "\033[42m"
+
+SEPARATOR = f"{DIM}{'─' * 72}{RESET}"
+
+
+def score_badge(score: int) -> str:
+    if score >= 90:
+        return f"{BG_GREEN}{BOLD} {score:>3} {RESET}"
+    if score >= 50:
+        return f"{BG_YELLOW}{BOLD} {score:>3} {RESET}"
+    return f"{BG_RED}{BOLD} {score:>3} {RESET}"
+
+
+def score_colour(score: float) -> str:
+    if score >= 0.9:
+        return GREEN
+    if score >= 0.5:
+        return YELLOW
+    return RED
+
+
+def priority_label(score: float | None, savings_ms: float) -> tuple[int, str]:
+    """Return (sort_key, label) — lower key = higher priority."""
+    if savings_ms > 500 or (score is not None and score == 0):
+        return 1, f"{RED}{BOLD}HIGH{RESET}"
+    if savings_ms > 100 or (score is not None and score < 0.5):
+        return 2, f"{YELLOW}{BOLD}MEDIUM{RESET}"
+    return 3, f"{GREEN}LOW{RESET}"
+
+
+def fmt_ms(ms: float) -> str:
+    if ms >= 1000:
+        return f"{ms / 1000:.1f} s"
+    return f"{ms:.0f} ms"
+
+
+def fmt_bytes(b: float) -> str:
+    if b >= 1024 * 1024:
+        return f"{b / (1024 * 1024):.1f} MB"
+    if b >= 1024:
+        return f"{b / 1024:.1f} KB"
+    return f"{b:.0f} B"
+
+
+# ── Report parsing ───────────────────────────────────────
+
+
+def load_report(preset: str) -> dict:
+    p = REPORT_DIR / f"latest-{preset}.report.json"
+    if not p.exists():
+        sys.exit(f"❌ Report not found: {p}\n   Run:  just lighthouse --{preset}")
+    return json.loads(p.read_text())
+
+
+def print_scores(data: dict, preset: str) -> None:
+    cats = data["categories"]
+    print()
+    print(f"  {BOLD}{CYAN}{'═' * 50}{RESET}")
+    print(f"  {BOLD}{CYAN}  LIGHTHOUSE — {preset.upper()}{RESET}")
+    print(f"  {BOLD}{CYAN}{'═' * 50}{RESET}")
+    print()
+    for key in ("performance", "accessibility", "best-practices", "seo"):
+        cat = cats[key]
+        score = int(cat["score"] * 100)
+        print(f"    {score_badge(score)}  {cat['title']}")
+    print()
+
+
+def collect_opportunities(data: dict) -> list[dict]:
+    """Collect failed/partial audits with actionable savings."""
+    results = []
+    for _key, audit in data["audits"].items():
+        score = audit.get("score")
+        mode = audit.get("scoreDisplayMode", "")
+        if mode in ("notApplicable", "manual"):
+            continue
+        if score is None or score >= 1:
+            continue
+
+        savings = audit.get("metricSavings", {})
+        total_savings_ms = sum(
+            v for v in savings.values() if isinstance(v, (int, float))
+        )
+        numeric = audit.get("numericValue", 0) or 0
+        display_value = audit.get("displayValue", "")
+        items = audit.get("details", {}).get("items", [])
+
+        results.append(
+            {
+                "title": audit["title"],
+                "score": score,
+                "description": audit.get("description", "").split("[")[0].strip(),
+                "display_value": display_value,
+                "savings_ms": total_savings_ms,
+                "numeric_value": numeric,
+                "items": items,
+                "category": _find_category(data, _key),
+            }
+        )
+    return results
+
+
+def _find_category(data: dict, audit_id: str) -> str:
+    for cat_key, cat in data["categories"].items():
+        for ref in cat.get("auditRefs", []):
+            if ref["id"] == audit_id:
+                return cat_key
+    return "other"
+
+
+CATEGORY_ICONS = {
+    "performance": "⚡",
+    "accessibility": "♿",
+    "best-practices": "✅",
+    "seo": "🔍",
+    "other": "📋",
+}
+
+CATEGORY_ORDER = {
+    "performance": 0,
+    "accessibility": 1,
+    "best-practices": 2,
+    "seo": 3,
+    "other": 4,
+}
+
+
+def print_opportunities(opps: list[dict]) -> None:
+    if not opps:
+        print(f"  {GREEN}{BOLD}No issues found — all audits passed!{RESET}")
+        return
+
+    # Sort: priority first, then by savings_ms descending
+    decorated = []
+    for idx, o in enumerate(opps):
+        pri_key, pri_label = priority_label(o["score"], o["savings_ms"])
+        decorated.append(
+            (
+                pri_key,
+                -o["savings_ms"],
+                CATEGORY_ORDER.get(o["category"], 9),
+                idx,
+                o,
+                pri_label,
+            )
+        )
+    decorated.sort()
+
+    current_priority = None
+    for pri_key, _, _, _idx, o, _pri_label in decorated:
+        if pri_key != current_priority:
+            current_priority = pri_key
+            header = {
+                1: "HIGH PRIORITY",
+                2: "MEDIUM PRIORITY",
+                3: "LOW PRIORITY",
+            }[pri_key]
+            colour = {1: RED, 2: YELLOW, 3: GREEN}[pri_key]
+            print(SEPARATOR)
+            print(f"  {colour}{BOLD}▸ {header}{RESET}")
+            print(SEPARATOR)
+            print()
+
+        icon = CATEGORY_ICONS.get(o["category"], "📋")
+        sc = score_colour(o["score"])
+        score_pct = int(o["score"] * 100)
+
+        print(f"  {icon} {BOLD}{o['title']}{RESET}  {sc}({score_pct}%){RESET}", end="")
+        if o["display_value"]:
+            print(f"  {DIM}— {o['display_value']}{RESET}", end="")
+        print()
+
+        if o["savings_ms"]:
+            print(f"     {MAGENTA}Potential savings: {fmt_ms(o['savings_ms'])}{RESET}")
+
+        if o["description"]:
+            desc = o["description"][:120]
+            print(f"     {DIM}{desc}{RESET}")
+
+        # Show top items (URLs, elements, etc.)
+        items = o["items"][:5]
+        if items:
+            print(f"     {DIM}┌{'─' * 60}{RESET}")
+            for item in items:
+                line = _format_item(item)
+                if line:
+                    print(f"     {DIM}│{RESET} {line}")
+            if len(o["items"]) > 5:
+                print(f"     {DIM}│ … and {len(o['items']) - 5} more{RESET}")
+            print(f"     {DIM}└{'─' * 60}{RESET}")
+        print()
+
+
+def _format_item(item: dict) -> str:
+    """Format a single detail item into a readable line."""
+    parts = []
+
+    # URL (truncate CDN paths)
+    url = item.get("url", "")
+    if url:
+        short = url.replace("https://cdn.jsdelivr.net/npm/", "cdn:")
+        short = short.replace(
+            "https://yoyonel.github.io/rpi-internet-monitoring/",
+            "./",
+        )
+        short = short.replace("https://fonts.googleapis.com/", "fonts:")
+        parts.append(f"{CYAN}{short}{RESET}")
+
+    # Node/element selector
+    node = item.get("node", {})
+    if isinstance(node, dict) and node.get("selector"):
+        parts.append(f"{MAGENTA}{node['selector']}{RESET}")
+
+    # Wasted bytes
+    wasted = item.get("wastedBytes", 0)
+    if wasted:
+        parts.append(f"{YELLOW}-{fmt_bytes(wasted)}{RESET}")
+
+    # Wasted ms
+    wasted_ms = item.get("wastedMs", 0)
+    if wasted_ms:
+        parts.append(f"{YELLOW}-{fmt_ms(wasted_ms)}{RESET}")
+
+    # Total bytes
+    total = item.get("totalBytes", 0)
+    if total and not wasted:
+        parts.append(f"{DIM}({fmt_bytes(total)}){RESET}")
+
+    # SubItems (e.g. contrast ratio)
+    sub = item.get("subItems", {}).get("items", [])
+    if sub:
+        for s in sub[:2]:
+            for _k, v in s.items():
+                if isinstance(v, str) and v:
+                    parts.append(f"{DIM}{v}{RESET}")
+                    break
+
+    return "  ".join(parts) if parts else ""
+
+
+def print_quick_wins(opps: list[dict]) -> None:
+    """Show a short summary of the easiest wins."""
+    # Quick wins = high savings, simple fixes
+    quick_cats = ("accessibility", "seo", "best-practices")
+    wins = [o for o in opps if o["category"] in quick_cats and o["score"] == 0]
+    if not wins:
+        return
+
+    print(SEPARATOR)
+    print(f"  {CYAN}{BOLD}⚡ QUICK WINS (non-performance, easy fixes){RESET}")
+    print(SEPARATOR)
+    print()
+    for w in wins:
+        icon = CATEGORY_ICONS.get(w["category"], "📋")
+        print(f"  {icon} {w['title']}")
+        if w["description"]:
+            print(f"     {DIM}{w['description'][:120]}{RESET}")
+        print()
+
+
+# ── Main ─────────────────────────────────────────────────
+
+
+def analyse(preset: str) -> None:
+    data = load_report(preset)
+    print_scores(data, preset)
+    opps = collect_opportunities(data)
+    print_quick_wins(opps)
+    print_opportunities(opps)
+
+
+def main() -> None:
+    arg = sys.argv[1] if len(sys.argv) > 1 else "both"
+    presets = ["mobile", "desktop"] if arg == "both" else [arg]
+
+    for preset in presets:
+        analyse(preset)
+
+    print(SEPARATOR)
+    print(f"  {DIM}Full HTML reports:{RESET}")
+    for preset in presets:
+        p = REPORT_DIR / f"latest-{preset}.report.html"
+        print(f"    {CYAN}{p}{RESET}")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lighthouse.sh
+++ b/scripts/lighthouse.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Run Lighthouse audits against the production GitHub Pages site.
+#
+# Usage: bash scripts/lighthouse.sh [--mobile|--desktop|--both] [--open]
+#   --mobile   Audit mobile only (default)
+#   --desktop  Audit desktop only
+#   --both     Audit both mobile and desktop (default if no flag)
+#   --open     Open HTML reports in browser after audit
+#
+# Reports are saved to lighthouse-reports/ with timestamped filenames.
+set -euo pipefail
+
+URL="https://yoyonel.github.io/rpi-internet-monitoring/"
+OUT_DIR="lighthouse-reports"
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+OPEN=false
+PRESETS=()
+
+for arg in "$@"; do
+    case "$arg" in
+        --mobile) PRESETS+=(mobile) ;;
+        --desktop) PRESETS+=(desktop) ;;
+        --both) PRESETS=(mobile desktop) ;;
+        --open) OPEN=true ;;
+        *)
+            echo "Unknown argument: $arg"
+            exit 1
+            ;;
+    esac
+done
+
+# Default: both
+if [[ ${#PRESETS[@]} -eq 0 ]]; then
+    PRESETS=(mobile desktop)
+fi
+
+# Check lighthouse is installed
+if ! command -v lighthouse &>/dev/null; then
+    echo "❌ lighthouse CLI not found. Install with:"
+    echo "   npm install -g lighthouse"
+    exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+badge() {
+    if (($1 >= 90)); then
+        echo "🟢"
+    elif (($1 >= 50)); then
+        echo "🟠"
+    else
+        echo "🔴"
+    fi
+}
+
+for preset in "${PRESETS[@]}"; do
+    echo ""
+    echo "══════════════════════════════════════════════"
+    echo "  Lighthouse — ${preset^^} — $URL"
+    echo "══════════════════════════════════════════════"
+
+    REPORT_NAME="${OUT_DIR}/${TIMESTAMP}-${preset}"
+
+    ARGS=(
+        "$URL"
+        --output html --output json
+        --output-path "$REPORT_NAME"
+        --chrome-flags="--headless --no-sandbox"
+    )
+    if [[ "$preset" == "desktop" ]]; then
+        ARGS+=(--preset desktop)
+    fi
+
+    lighthouse "${ARGS[@]}"
+
+    # Extract scores
+    JSON="${REPORT_NAME}.report.json"
+    read_score() {
+        python3 -c "import json; d=json.load(open('$JSON')); print(int(d['categories']['$1']['score']*100))"
+    }
+
+    PERF=$(read_score performance)
+    A11Y=$(read_score accessibility)
+    BP=$(read_score best-practices)
+    SEO=$(read_score seo)
+
+    echo ""
+    echo "  ┌─────────────────────────────────┐"
+    echo "  │  ${preset^^} Results              "
+    echo "  ├─────────────────────────────────┤"
+    printf "  │  %s Performance    %3d          │\n" "$(badge "$PERF")" "$PERF"
+    printf "  │  %s Accessibility   %3d          │\n" "$(badge "$A11Y")" "$A11Y"
+    printf "  │  %s Best Practices  %3d          │\n" "$(badge "$BP")" "$BP"
+    printf "  │  %s SEO             %3d          │\n" "$(badge "$SEO")" "$SEO"
+    echo "  └─────────────────────────────────┘"
+    echo ""
+    echo "  HTML: ${REPORT_NAME}.report.html"
+    echo "  JSON: ${REPORT_NAME}.report.json"
+
+    if [[ "$OPEN" == true ]]; then
+        xdg-open "${REPORT_NAME}.report.html" 2>/dev/null ||
+            open "${REPORT_NAME}.report.html" 2>/dev/null ||
+            echo "  (could not auto-open report)"
+    fi
+done
+
+# Symlink latest reports for easy access
+for preset in "${PRESETS[@]}"; do
+    for ext in report.html report.json; do
+        src="${TIMESTAMP}-${preset}.${ext}"
+        link="${OUT_DIR}/latest-${preset}.${ext}"
+        ln -sf "$src" "$link"
+    done
+done
+
+echo ""
+echo "Done. Latest reports symlinked:"
+for preset in "${PRESETS[@]}"; do
+    echo "  ${OUT_DIR}/latest-${preset}.report.html"
+done


### PR DESCRIPTION
## Summary

Add Lighthouse performance auditing for the production GitHub Pages site, both in CI and locally.

### CI Workflow (`.github/workflows/lighthouse.yml`)
- **Triggers**: after each gh-pages deploy (`workflow_run`), weekly (Monday 06:00 UTC), manual (`workflow_dispatch`)
- **Matrix**: Mobile + Desktop in parallel
- **Output**: Job Summary with colored score badges + HTML/JSON artifacts (30-day retention)

### Local Tools
- `just lighthouse [--mobile|--desktop|--both] [--open]` — run Lighthouse audits against prod
- `just lighthouse-report [mobile|desktop|both]` — parse JSON reports into a prioritized action plan

Reports are saved to `lighthouse-reports/` (gitignored) with `latest-*` symlinks.

### Baseline Scores (2026-04-17)

|               | Mobile | Desktop |
|---------------|--------|---------|
| Performance   | 🔴 49  | 🟠 77   |
| Accessibility | 🟠 82  | 🟠 82   |
| Best Practices| 🟢 96  | 🟢 96   |
| SEO           | 🟢 90  | 🟢 90   |

### Commits (SoC)
1. `ci:` — Lighthouse CI workflow
2. `feat:` — Local scripts + Justfile recipes + .gitignore
3. `docs:` — README documentation
