### PR TITLE
perf: Lighthouse quick wins — a11y 100, SEO 100, Best Practices 100

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,6 +1,11 @@
 name: Lighthouse Audit
 
 on:
+  # Run on PRs that touch the frontend
+  pull_request:
+    paths:
+      - 'gh-pages/**'
+      - '.github/workflows/lighthouse.yml'
   # Run after each gh-pages deploy
   workflow_run:
     workflows: ['Deploy GitHub Pages']

--- a/README.md
+++ b/README.md
@@ -398,7 +398,31 @@ Le mode band chart est inspiré des boxplots : au lieu de tracer des milliers de
 | [LTTB](https://skemman.is/bitstream/1946/15343/3/SS_MSthesis.pdf)                                                        | Downsampling préservant les pics                   |
 | Float64Array                                                                                                             | Stockage mémoire compact, itération cache-friendly |
 | requestAnimationFrame                                                                                                    | Debounce du rendering                              |
-| Geist / Geist Mono                                                                                                       | Typographie (Google Fonts)                         |
+| Geist / Geist Mono                                                                                                       | Typographie (Google Fonts, async preload)          |
+
+### Performance & Accessibilité
+
+Optimisations appliquées pour maximiser les scores [Lighthouse](https://developer.chrome.com/docs/lighthouse/) :
+
+| Optimisation                                                    | Impact                                           |
+| --------------------------------------------------------------- | ------------------------------------------------ |
+| `defer` sur tous les `<script>` CDN                             | Élimine le render-blocking JS (-1.2 s mobile)    |
+| Preload async des Google Fonts                                  | Élimine le render-blocking CSS font              |
+| Auto-refresh via `setTimeout` (pas `<meta http-equiv=refresh>`) | Accessibilité : pas de refresh inattendu         |
+| `<main>` landmark                                               | Screen readers : navigation structurée           |
+| `<meta name="description">`                                     | SEO : description dans les résultats             |
+| Contrastes WCAG AA (≥ 4.5:1)                                    | `--text2` 7.7:1, `--text3` 5.8:1, `.rb.on` 9.2:1 |
+| Liens distinguables (underline)                                 | Pas de dépendance couleur seule                  |
+| `<link rel="icon" href="data:,">`                               | Supprime l'erreur console 404 favicon            |
+
+**Scores Lighthouse (avril 2026)** :
+
+|                | Mobile | Desktop |
+| -------------- | :----: | :-----: |
+| Performance    | 🟠 ~60 | 🟠 ~80  |
+| Accessibility  | 🟢 100 | 🟢 100  |
+| Best Practices | 🟢 100 | 🟢 100  |
+| SEO            | 🟢 100 | 🟢 100  |
 
 ### Commandes
 

--- a/gh-pages/app.js
+++ b/gh-pages/app.js
@@ -467,7 +467,7 @@
   const statCard = (cls, label, mainVal, items, nPts, timeRange) =>
     `<div class="stat ${cls}">
       <div class="v">${mainVal}</div>
-      <div class="l">${label} <span style="font-size:.85em;opacity:.5">m\u00e9diane</span></div>
+      <div class="l">${label} <span class="l-sub">m\u00e9diane</span></div>
       <dl class="sg">${items.map(([k, v]) => `<dt>${k}</dt><dd>${v}</dd>`).join('')}</dl>
       <div class="pts">${timeRange} \u00b7 ${nPts} pts</div>
     </div>`;

--- a/gh-pages/index.template.html
+++ b/gh-pages/index.template.html
@@ -4,19 +4,33 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="refresh" content="660" />
+    <link rel="icon" href="data:," />
+    <meta
+      name="description"
+      content="Tableau de bord temps réel du débit internet via Speedtest Ookla sur Raspberry Pi 4. Download, upload, latence — mis à jour toutes les 10 minutes."
+    />
     <title>Internet Speed Monitor — RPi4</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
+      rel="preload"
       href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&display=swap"
-      rel="stylesheet"
+      as="style"
+      onload="
+        this.onload = null;
+        this.rel = 'stylesheet';
+      "
     />
+    <noscript
+      ><link
+        href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&display=swap"
+        rel="stylesheet"
+    /></noscript>
     <link rel="stylesheet" href="style.css" />
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3"></script>
-    <script src="https://cdn.jsdelivr.net/npm/hammerjs@2"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/hammerjs@2"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2"></script>
   </head>
   <body>
     <nav>
@@ -26,7 +40,7 @@
       </div>
     </nav>
 
-    <div class="w">
+    <main class="w">
       <section class="hero">
         <h1>Internet Speed Monitor</h1>
         <p class="sub">Raspberry Pi 4 &mdash; Speedtest Ookla toutes les 10 min</p>
@@ -102,7 +116,7 @@
         </div>
         <canvas id="piChart"></canvas>
       </div>
-    </div>
+    </main>
 
     <footer>
       <p>
@@ -115,6 +129,11 @@
       const RAW_DATA = '__SPEEDTEST_DATA__';
       const ALERTS = '__ALERTS_DATA__';
     </script>
-    <script src="app.js"></script>
+    <script defer src="app.js"></script>
+    <script>
+      setTimeout(function () {
+        location.reload();
+      }, 660000);
+    </script>
   </body>
 </html>

--- a/gh-pages/style.css
+++ b/gh-pages/style.css
@@ -11,8 +11,8 @@
   --border: #2a2a2d;
   --border2: #333336;
   --text: #ededed;
-  --text2: #888;
-  --text3: #555;
+  --text2: #9ca3af;
+  --text3: #8b8b93;
   --blue: #7eb6f6;
   --purple: #c982e0;
   --orange: #f2a93b;
@@ -37,7 +37,8 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
-.w {
+.w,
+main.w {
   max-width: 960px;
   margin: 0 auto;
   padding: 0 20px;
@@ -128,6 +129,10 @@ nav .meta time {
   margin-top: 6px;
   text-transform: uppercase;
   letter-spacing: 0.06em;
+}
+.stat .l-sub {
+  font-size: 0.85em;
+  text-transform: none;
 }
 .stat.pi .v {
   color: var(--orange);
@@ -299,7 +304,7 @@ nav .meta time {
 }
 .tp .rb.on {
   background: var(--blue);
-  color: #fff;
+  color: var(--bg);
 }
 .tp .rl {
   font-size: 0.72rem;
@@ -619,7 +624,8 @@ footer p {
 }
 footer a {
   color: var(--blue);
-  text-decoration: none;
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 footer a:hover {
   text-decoration: underline;


### PR DESCRIPTION
## Summary

Quick wins issus de l'analyse Lighthouse (baseline: Mobile 49/82/96/90, Desktop 77/82/96/90).

### Commit 1 — `perf:` Render-blocking & font loading

- `defer` sur tous les `<script>` CDN (chart.js, hammerjs, chartjs-adapter, chartjs-zoom)
- `defer` sur `app.js`
- Chargement asynchrone Google Fonts via `rel=preload` + `onload` swap
- Remplacement `<meta http-equiv=refresh>` par `setTimeout` JS
- Ajout `<link rel=icon href="data:,">` pour éviter le 404 favicon

### Commit 2 — `fix(a11y):` Contraste + SEO + landmarks

- `--text2`: `#888` → `#9ca3af` (ratio 7.7:1)
- `--text3`: `#555` → `#8b8b93` (ratio 5.8:1)
- Bouton actif `.rb.on`: `#fff` → `var(--bg)` sur fond `var(--blue)` (ratio 9.2:1)
- Remplacement `opacity:.5` inline par classe CSS `.l-sub`
- Ajout `text-decoration: underline` sur les liens footer
- Ajout `<meta name=description>`
- Wrapper contenu dans `<main>` (landmark)

### Résultats (local preview)

|               | Avant (prod) | Après (local) |
|---------------|:------------:|:-------------:|
| Performance   | 🔴 49 / 🟠 77 | 🟠 53-72 / 🟠 78-80 |
| Accessibility | 🟠 82        | 🟢 **100**    |
| Best Practices| 🟢 96        | 🟢 **100**    |
| SEO           | 🟢 90        | 🟢 **100**    |

> Performance mobile varie 53-72 en local à cause du throttling CPU simulé par Lighthouse. Le gain réel sur prod (après deploy) sera plus stable.

### Validé par

- `just lint` ✅
- `just e2e` (12/12 tests) ✅
- Lighthouse local (mobile + desktop) ✅
