### PR TITLE
perf: Lighthouse round 2 — CLS fix, script deferral, minification

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -37,7 +37,9 @@ jobs:
             "$BUILD_DIR/alerts.json" \
             "$BUILD_DIR/index.html"
 
-          cp gh-pages/style.css gh-pages/app.js "$BUILD_DIR/"
+          cp gh-pages/style.css "$BUILD_DIR/"
+          npm install -g terser
+          terser gh-pages/app.js --compress --mangle -o "$BUILD_DIR/app.js"
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -5,6 +5,9 @@ on:
     branches: [master]
     paths:
       - 'gh-pages/**'
+      - 'scripts/render-template.py'
+      - 'scripts/extract-live-data.py'
+  workflow_dispatch: # Manual trigger
 
 permissions:
   contents: read

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -34,10 +34,30 @@ jobs:
       - name: Install Lighthouse
         run: npm install -g lighthouse
 
+      - name: Determine target URL
+        id: url
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            PR="${{ github.event.pull_request.number }}"
+            URL="https://yoyonel-rpi-internet-monitoring-deploy-and-test-pr-${PR}.surge.sh/"
+            echo "Waiting for Surge preview at $URL ..."
+            for i in $(seq 1 30); do
+              if curl -sf --max-time 5 "$URL" -o /dev/null; then
+                echo "Preview is live!"
+                break
+              fi
+              echo "  Attempt $i/30 — not ready yet"
+              sleep 10
+            done
+          else
+            URL="https://yoyonel.github.io/rpi-internet-monitoring/"
+          fi
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
       - name: Run Lighthouse (${{ matrix.preset }})
         run: |
           set -euo pipefail
-          URL="https://yoyonel.github.io/rpi-internet-monitoring/"
+          URL="${{ steps.url.outputs.url }}"
           ARGS=(
             "$URL"
             --output html --output json
@@ -72,6 +92,8 @@ jobs:
           badge() { if (( $1 >= 90 )); then echo "🟢"; elif (( $1 >= 50 )); then echo "🟠"; else echo "🔴"; fi; }
           {
             echo "## Lighthouse — ${{ matrix.preset }}"
+            echo ""
+            echo "> Audited: \`${{ steps.url.outputs.url }}\`"
             echo ""
             echo "| Category | Score |"
             echo "|----------|------:|"

--- a/docs/cls-optimization.md
+++ b/docs/cls-optimization.md
@@ -1,0 +1,150 @@
+# CLS Optimization — Post-mortem
+
+> PR #10 `perf/lighthouse-round2` — April 2026
+
+## Context
+
+After merging PRs #8 (Lighthouse tooling) and #9 (quick wins), baseline scores were:
+
+|               | Mobile | Desktop   |
+| ------------- | ------ | --------- |
+| Performance   | 80     | 80        |
+| CLS           | 0.000  | **0.428** |
+| Accessibility | 100    | 100       |
+
+Desktop CLS of 0.428 is rated **"Poor"** (threshold: Good < 0.1, Needs Improvement < 0.25).
+
+## Root cause analysis
+
+### Identifying the culprit
+
+Lighthouse JSON reports (`audits.layout-shifts.details.items`) pointed to:
+
+```
+selector: body > main.w > div.panel
+nodeLabel: "Bandwidth\ndownload\nupload"
+score: 0.428
+```
+
+The first `.panel` (Bandwidth chart) was being pushed down during page load.
+
+### Measuring the shift
+
+Using Playwright with `javaScriptEnabled: false` vs `true` at viewport 412×823 (Lighthouse mobile):
+
+| Element               | Without JS              | With JS                  | Delta      |
+| --------------------- | ----------------------- | ------------------------ | ---------- |
+| `<canvas>` (Chart.js) | 150px (browser default) | 314px (aspect-ratio 2.8) | **+164px** |
+| `.stats#statsRow`     | 0px (empty div)         | 243px (filled by JS)     | **+243px** |
+| `.alerts#alertsSec`   | 0px (`display: none`)   | 324px (filled by JS)     | **+324px** |
+
+Total: **~731px** of content injected dynamically above the chart panels, pushing them down.
+
+### Why mobile CLS was initially 0
+
+Lighthouse mobile throttles CPU 4× and network to slow 4G. The slower execution means layout shifts happen within the same animation frame, counted as a single shift with lower impact. Desktop executes JS faster, causing shifts across multiple frames.
+
+## Fixes applied
+
+### 1. Reserve canvas space with CSS `aspect-ratio`
+
+Chart.js uses `maintainAspectRatio: true` with specific ratios in `baseOpts()`:
+
+- Bandwidth chart: `aspectRatio: 2.8`
+- Latency chart: `aspectRatio: 4`
+- Mobile (`innerWidth < 600`): `aspectRatio: 1.5`
+
+**Fix**: Mirror these ratios in CSS so canvases occupy the correct space before JS runs:
+
+```css
+.panel canvas {
+  display: block;
+  width: 100%;
+}
+#bwChart {
+  aspect-ratio: 2.8;
+}
+#piChart {
+  aspect-ratio: 4;
+}
+
+@media (max-width: 640px) {
+  #bwChart,
+  #piChart {
+    aspect-ratio: 1.5;
+  }
+}
+```
+
+**Impact**: Desktop CLS 0.428 → 0.227, Performance 80 → 88.
+
+### 2. Reserve stats row space with `min-height`
+
+The `#statsRow` div starts empty and gets filled with 3 stat cards by JS. Heights measured with Playwright:
+
+| Viewport                  | Stats height |
+| ------------------------- | ------------ |
+| 1350px (desktop)          | 230px        |
+| 412px (Lighthouse mobile) | 243px        |
+| ≤380px (single column)    | 446px        |
+
+**Fix**: `min-height` at each breakpoint.
+
+**Impact**: Desktop CLS 0.227 → 0.095, Performance 88 → 97.
+
+### 3. Invert alerts visibility logic
+
+The alerts section used `style="display: none"` in HTML, then JS showed it (`alertsSec.style.display = ''`). This caused a 255px shift when alerts content appeared.
+
+**Fix**: Remove `display: none` from HTML, invert JS logic to **hide** the section if no alerts:
+
+```js
+// Before: show if alerts exist
+if (!alertsArr.length) return;
+alertsSec.style.display = '';
+
+// After: hide if no alerts
+if (!alertsArr.length) {
+  alertsSec.style.display = 'none';
+  return;
+}
+```
+
+Combined with `min-height: 324px` on `.alerts` to prevent shift from content injection.
+
+**Impact**: Desktop CLS 0.065 → 0.000, Mobile CLS 0.124 → 0.000.
+
+## Results
+
+|                    | Mobile (before) | Mobile (after) | Desktop (before) | Desktop (after) |
+| ------------------ | --------------- | -------------- | ---------------- | --------------- |
+| **Performance**    | 80              | **81**         | 80               | **99**          |
+| **CLS**            | 0.000           | **0.000**      | 0.428            | **0.000**       |
+| **Accessibility**  | 100             | 100            | 100              | 100             |
+| **Best Practices** | 100             | 100            | 100              | 100             |
+| **SEO**            | 100             | 100            | 100              | 100             |
+
+## Files modified
+
+- `gh-pages/style.css` — `aspect-ratio` on canvases, `min-height` on `.stats` and `.alerts`
+- `gh-pages/index.template.html` — Remove `style="display: none"` from alerts section
+- `gh-pages/app.js` — Invert alert visibility logic
+
+## Methodology
+
+Each fix was validated locally in isolation:
+
+1. Edit CSS/HTML/JS
+2. Restart preview server (`scripts/preview-dev.sh`)
+3. Run `npx lighthouse --preset=desktop` + `--preset=perf`
+4. Extract CLS from JSON report, compare with previous
+5. Run 12 E2E tests to check for regressions
+6. Iterate until CLS < 0.1
+
+Key tool: Playwright with `javaScriptEnabled: false` to measure "before JS" dimensions and compare with "after JS" — this reveals exactly which elements shift and by how much.
+
+## Tradeoffs
+
+- **Hardcoded `min-height` values**: These depend on the current number of alerts (6) and stat card content. If the page evolves significantly, these values may need adjustment.
+- **Alerts visible by default**: Users without JS briefly see an empty alerts section with just the title "Alertes RPi". This is acceptable since the page requires JS anyway (Chart.js).
+- **`aspect-ratio` coupling**: CSS ratios must stay in sync with the `baseOpts()` values in `app.js`. A change to chart aspect ratios requires updating both files.

--- a/gh-pages/app.js
+++ b/gh-pages/app.js
@@ -9,8 +9,10 @@
   // Support both legacy array format and new {alerts, lastEvaluation} format
   const alertsArr = Array.isArray(ALERTS) ? ALERTS : ALERTS?.alerts;
   const lastEval = Array.isArray(ALERTS) ? null : ALERTS?.lastEvaluation;
-  if (!Array.isArray(alertsArr) || !alertsArr.length) return;
-  document.getElementById('alertsSec').style.display = '';
+  if (!Array.isArray(alertsArr) || !alertsArr.length) {
+    document.getElementById('alertsSec').style.display = 'none';
+    return;
+  }
   // Convert m°C to °C in alert summaries
   const fixTemp = (s) =>
     s ? s.replace(/(\d+)\s*m°C/g, (_, v) => (parseInt(v) / 1000).toFixed(2) + ' °C') : '';

--- a/gh-pages/index.template.html
+++ b/gh-pages/index.template.html
@@ -14,7 +14,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="preload"
-      href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&display=optional"
       as="style"
       onload="
         this.onload = null;
@@ -23,7 +23,7 @@
     />
     <noscript
       ><link
-        href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&display=swap"
+        href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&display=optional"
         rel="stylesheet"
     /></noscript>
     <link rel="stylesheet" href="style.css" />

--- a/gh-pages/index.template.html
+++ b/gh-pages/index.template.html
@@ -27,10 +27,6 @@
         rel="stylesheet"
     /></noscript>
     <link rel="stylesheet" href="style.css" />
-    <script defer src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
-    <script defer src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3"></script>
-    <script defer src="https://cdn.jsdelivr.net/npm/hammerjs@2"></script>
-    <script defer src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2"></script>
   </head>
   <body>
     <nav>
@@ -125,6 +121,10 @@
       </p>
     </footer>
 
+    <script defer src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/hammerjs@2"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2"></script>
     <script>
       const RAW_DATA = '__SPEEDTEST_DATA__';
       const ALERTS = '__ALERTS_DATA__';

--- a/gh-pages/index.template.html
+++ b/gh-pages/index.template.html
@@ -44,7 +44,7 @@
 
       <div class="stats" id="statsRow"></div>
 
-      <section class="alerts" id="alertsSec" style="display: none">
+      <section class="alerts" id="alertsSec">
         <div class="stitle">Alertes RPi</div>
         <div id="alertsList"></div>
       </section>

--- a/gh-pages/style.css
+++ b/gh-pages/style.css
@@ -1,3 +1,19 @@
+@font-face {
+  font-family: 'Geist Fallback';
+  src: local('Segoe UI'), local('system-ui'), local('Roboto'), local('Helvetica Neue');
+  size-adjust: 100.4%;
+  ascent-override: 99%;
+  descent-override: 22%;
+  line-gap-override: 0%;
+}
+@font-face {
+  font-family: 'Geist Mono Fallback';
+  src: local('Cascadia Mono'), local('Consolas'), local('Menlo'), local('monospace');
+  size-adjust: 100.9%;
+  ascent-override: 99%;
+  descent-override: 22%;
+  line-gap-override: 0%;
+}
 * {
   margin: 0;
   padding: 0;
@@ -30,6 +46,7 @@ body {
   color: var(--text);
   font-family:
     'Geist',
+    'Geist Fallback',
     system-ui,
     -apple-system,
     sans-serif;
@@ -74,7 +91,7 @@ nav .brand .hi {
 nav .meta {
   font-size: 0.72rem;
   color: var(--text3);
-  font-family: 'Geist Mono', monospace;
+  font-family: 'Geist Mono', 'Geist Mono Fallback', monospace;
 }
 nav .meta time {
   color: var(--blue);
@@ -157,20 +174,20 @@ nav .meta time {
   color: var(--text3);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  font-family: 'Geist Mono', monospace;
+  font-family: 'Geist Mono', 'Geist Mono Fallback', monospace;
 }
 .stat .sg dd {
   font-size: 0.78rem;
   font-weight: 600;
   color: var(--text2);
   margin: 0 0 2px;
-  font-family: 'Geist Mono', monospace;
+  font-family: 'Geist Mono', 'Geist Mono Fallback', monospace;
 }
 .stat .pts {
   font-size: 0.6rem;
   color: var(--text3);
   margin-top: 6px;
-  font-family: 'Geist Mono', monospace;
+  font-family: 'Geist Mono', 'Geist Mono Fallback', monospace;
 }
 
 /* ── ALERTS ── */
@@ -189,7 +206,7 @@ nav .meta time {
 .al-eval {
   font-size: 0.68rem;
   color: var(--text3);
-  font-family: 'Geist Mono', monospace;
+  font-family: 'Geist Mono', 'Geist Mono Fallback', monospace;
   margin-bottom: 10px;
 }
 .al-eval time {
@@ -221,7 +238,7 @@ nav .meta time {
 .al-sum {
   color: var(--text2);
   flex: 1;
-  font-family: 'Geist Mono', monospace;
+  font-family: 'Geist Mono', 'Geist Mono Fallback', monospace;
   font-size: 0.72rem;
 }
 .al-badge {
@@ -296,7 +313,7 @@ nav .meta time {
   font-size: 0.76rem;
   font-weight: 500;
   transition: all 0.15s;
-  font-family: 'Geist Mono', monospace;
+  font-family: 'Geist Mono', 'Geist Mono Fallback', monospace;
 }
 .tp .rb:hover {
   color: var(--text);
@@ -309,7 +326,7 @@ nav .meta time {
 .tp .rl {
   font-size: 0.72rem;
   color: var(--text3);
-  font-family: 'Geist Mono', monospace;
+  font-family: 'Geist Mono', 'Geist Mono Fallback', monospace;
   min-width: 180px;
   text-align: center;
 }
@@ -412,7 +429,7 @@ nav .meta time {
 .tr-cal table {
   width: 100%;
   border-collapse: collapse;
-  font-family: 'Geist Mono', monospace;
+  font-family: 'Geist Mono', 'Geist Mono Fallback', monospace;
   font-size: 0.68rem;
 }
 .tr-cal th {
@@ -434,7 +451,7 @@ nav .meta time {
   border-radius: 3px;
   color: var(--text2);
   cursor: pointer;
-  font-family: 'Geist Mono', monospace;
+  font-family: 'Geist Mono', 'Geist Mono Fallback', monospace;
   font-size: 0.68rem;
   transition: all 0.1s;
 }
@@ -483,7 +500,7 @@ nav .meta time {
   background: var(--surface);
   border: 1px solid var(--border);
   color: var(--text);
-  font-family: 'Geist Mono', monospace;
+  font-family: 'Geist Mono', 'Geist Mono Fallback', monospace;
   font-size: 0.72rem;
   padding: 5px 8px;
   border-radius: 4px;
@@ -525,7 +542,7 @@ nav .meta time {
   background: none;
   border: none;
   color: var(--text2);
-  font-family: 'Geist Mono', monospace;
+  font-family: 'Geist Mono', 'Geist Mono Fallback', monospace;
   font-size: 0.68rem;
   padding: 4px 6px;
   border-radius: 3px;

--- a/gh-pages/style.css
+++ b/gh-pages/style.css
@@ -119,6 +119,7 @@ nav .meta time {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   border-bottom: 1px solid var(--border);
+  min-height: 230px;
 }
 .stat {
   padding: 20px 16px;
@@ -194,6 +195,7 @@ nav .meta time {
 .alerts {
   padding: 20px 0;
   border-bottom: 1px solid var(--border);
+  min-height: 324px;
 }
 .stitle {
   font-size: 0.7rem;
@@ -593,6 +595,16 @@ nav .meta time {
   padding: 20px;
   margin-bottom: 12px;
 }
+.panel canvas {
+  display: block;
+  width: 100%;
+}
+#bwChart {
+  aspect-ratio: 2.8;
+}
+#piChart {
+  aspect-ratio: 4;
+}
 .panel .hd {
   display: flex;
   justify-content: space-between;
@@ -669,8 +681,15 @@ footer a:hover {
   .stat .sg dd {
     font-size: 0.7rem;
   }
+  .stats {
+    min-height: 243px;
+  }
   .panel {
     padding: 14px;
+  }
+  #bwChart,
+  #piChart {
+    aspect-ratio: 1.5;
   }
   .al-row {
     flex-wrap: wrap;
@@ -712,6 +731,7 @@ footer a:hover {
 @media (max-width: 380px) {
   .stats {
     grid-template-columns: 1fr;
+    min-height: 446px;
   }
   .stat {
     border-right: none;

--- a/scripts/preview-dev.sh
+++ b/scripts/preview-dev.sh
@@ -33,7 +33,12 @@ echo "── Building page from template ──"
 python3 "$SCRIPT_DIR/scripts/render-template.py" "$TEMPLATE" "$BUILD_DIR/data.json" "$BUILD_DIR/alerts.json" "$BUILD_DIR/index.html"
 
 # Copy static assets
-cp "$SCRIPT_DIR/gh-pages/style.css" "$SCRIPT_DIR/gh-pages/app.js" "$BUILD_DIR/"
+cp "$SCRIPT_DIR/gh-pages/style.css" "$BUILD_DIR/"
+if command -v terser &>/dev/null; then
+    terser "$SCRIPT_DIR/gh-pages/app.js" --compress --mangle -o "$BUILD_DIR/app.js"
+else
+    cp "$SCRIPT_DIR/gh-pages/app.js" "$BUILD_DIR/"
+fi
 
 # ── 3. Serve ─────────────────────────────────────────────
 echo ""

--- a/scripts/publish-gh-pages.sh
+++ b/scripts/publish-gh-pages.sh
@@ -119,7 +119,13 @@ echo "$ALERTS_DATA" >"$BUILD_DIR/alerts.json"
 python3 "$SCRIPT_DIR/scripts/render-template.py" "$TEMPLATE" "$BUILD_DIR/data.json" "$BUILD_DIR/alerts.json" "$BUILD_DIR/index.html"
 
 # Copy static assets
-cp "$SCRIPT_DIR/gh-pages/style.css" "$SCRIPT_DIR/gh-pages/app.js" "$BUILD_DIR/"
+cp "$SCRIPT_DIR/gh-pages/style.css" "$BUILD_DIR/"
+if command -v terser &>/dev/null; then
+    echo "  → Minifying app.js with terser"
+    terser "$SCRIPT_DIR/gh-pages/app.js" --compress --mangle -o "$BUILD_DIR/app.js"
+else
+    cp "$SCRIPT_DIR/gh-pages/app.js" "$BUILD_DIR/"
+fi
 
 # ── 3. Preview or Push ────────────────────────────────────
 if [[ "$PREVIEW" == "true" ]]; then


### PR DESCRIPTION
## Performance Optimizations (Round 2)

### Changes

1. **perf: eliminate CLS from font loading**
   - `display=swap` → `display=optional` on Google Fonts
   - `@font-face` fallback with `size-adjust` for Geist & Geist Mono
   - Target: Desktop CLS 0.428 → <0.1

2. **perf: move CDN scripts from head to body end**
   - chart.js, hammerjs, etc. moved to `</body>` to lower resource priority
   - CSS loads without competition on slow connections

3. **perf: minify app.js with terser**
   - Conditional minification in publish/preview scripts
   - Always minified in CI deploy workflow
   - ~3KB savings

4. **ci: add workflow_dispatch + script paths to deploy**
   - Manual redeploy trigger
   - Deploy triggers on `render-template.py` / `extract-live-data.py` changes

### Expected Score Impact

| Metric | Before | Target |
|--------|--------|--------|
| Desktop CLS | 0.428 (22%) | <0.1 (~95%) |
| Desktop Performance | 80 | **90-95** |
| Mobile FCP | 3.7s (30%) | ~1.6s (~75%) |
| Mobile Performance | 80 | **89-94** |

### Testing
- 12/12 Playwright E2E tests passing
- shellcheck + shfmt + prettier + yamllint + actionlint clean