### PR TITLE
fix: timezone indicator on timestamps + remove duplicate threshold

### DIFF
--- a/docs/gh-pages-deployment-analysis.md
+++ b/docs/gh-pages-deployment-analysis.md
@@ -1,0 +1,55 @@
+# GitHub Pages — Deployment Analysis
+
+## Constat : deux acteurs écrivent sur `gh-pages`
+
+|                        | **RPI (systemd timer)**                                                    | **CI (GitHub Actions)**                                                                         |
+| ---------------------- | -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| **Script**             | `scripts/publish-gh-pages.sh`                                              | `.github/workflows/deploy-gh-pages.yml`                                                         |
+| **Trigger**            | `publish-gh-pages.timer` → toutes les 10 min                               | Push sur `master` (paths: `gh-pages/**`, `render-template.py`, `extract-live-data.py`) + manual |
+| **Source des données** | InfluxDB local (Docker) + Grafana API locale (alertes)                     | `curl` du site live → `extract-live-data.py` pour re-extraire les données                       |
+| **Template**           | `gh-pages/index.template.html`                                             | `gh-pages/index.template.html`                                                                  |
+| **Méthode push**       | `git push --force-with-lease` vers branche `gh-pages`                      | `upload-pages-artifact` + `deploy-pages` (GitHub Actions Pages API)                             |
+| **Contenu**            | `index.html, style.css, app.js, data.json, alerts.json, fonts/, .nojekyll` | Idem, via artifact → Pages API                                                                  |
+
+## Conflit de déploiement
+
+```
+RPI (toutes les 10 min)                CI (à chaque push master)
+        │                                       │
+        ▼                                       ▼
+  git push --force-with-lease          upload-pages-artifact
+  → branche gh-pages                   → GitHub Pages API (Actions)
+        │                                       │
+        └───────── CONFLIT ─────────────────────┘
+                      │
+              GitHub Pages sert QUOI ?
+              → Config repo = "Deploy from branch: gh-pages"
+              → Le RPI gagne (branche)
+              → Le workflow CI écrit dans le vide (artifact API)
+```
+
+**Le workflow CI ne fait rien d'utile en prod.** Il upload un artifact Pages, mais le repo est configuré en mode legacy (branche `gh-pages`). Donc :
+
+- Le RPI push `--force-with-lease` sur `gh-pages` toutes les 10 min → **c'est lui qui alimente le site**
+- Le CI upload un artifact que personne ne sert
+- Le CI fetch les données depuis le site live (que le RPI a mis à jour) pour les re-injecter dans un artifact inutile
+
+## Problème secondaire : `extract-live-data.py`
+
+Le workflow CI utilise `extract-live-data.py` pour récupérer les données depuis le site live. Depuis la PR #11, les données sont dans `data.json`/`alerts.json` (fichiers séparés) au lieu d'être inline dans le HTML. Le script actuel (sur master) cherche `RAW_DATA = {...}` dans le HTML → il ne trouve plus rien.
+
+## Questions ouvertes
+
+1. **Quel est le rôle voulu du workflow CI ?**
+   - Option A : rebuild du template seulement (quand `gh-pages/**` change sur master) → ne touche pas aux données, re-render HTML/CSS/JS avec les données existantes sur la branche `gh-pages`
+   - Option B : déploiement complet indépendant → doit passer en mode `git push` sur la branche (comme le RPI), mais race condition avec le timer 10 min
+
+2. **Le CI doit-il utiliser des données locales ou distantes ?**
+   - Le RPI a les données fraîches (InfluxDB + Grafana)
+   - Le CI n'a pas accès à InfluxDB → il dépend forcément de données existantes (site live ou branche gh-pages)
+   - Faut-il que le CI récupère `data.json`/`alerts.json` depuis la branche `gh-pages` directement (git checkout) au lieu de curl le site ?
+
+3. **Faut-il aligner la méthode de déploiement ?**
+   - Le RPI utilise `git push` → cohérent avec la config legacy du repo
+   - Le CI utilise Actions Pages API → incohérent avec la config legacy
+   - → Le CI devrait probablement utiliser `git push` aussi, ou on change la config repo en mode Actions Pages (mais alors le RPI ne peut plus push)

--- a/gh-pages/app.js
+++ b/gh-pages/app.js
@@ -19,9 +19,15 @@ _dataReady.then(([, ALERTS]) => {
     document.getElementById('alertsSec').style.display = 'none';
     return;
   }
-  // Convert m°C to °C in alert summaries
-  const fixTemp = (s) =>
-    s ? s.replace(/(\d+)\s*m°C/g, (_, v) => (parseInt(v) / 1000).toFixed(2) + ' °C') : '';
+  // Convert m°C to °C in alert summaries and remove duplicate thresholds
+  const fixTemp = (s) => {
+    if (!s) return '';
+    // Convert millidegrees to degrees: "70000 m°C" → "70.00 °C"
+    let r = s.replace(/(\d+)\s*m°C/g, (_, v) => (parseInt(v) / 1000).toFixed(2) + ' °C');
+    // Remove "/ 70°C" duplicate after converted threshold: "(threshold: 70.00 °C / 70°C)"
+    r = r.replace(/(\d+\.?\d*\s*°C)\s*\/\s*\d+\.?\d*\s*°C/g, '$1');
+    return r;
+  };
 
   // Format lastEvaluation timestamp
   const fmtEval = (iso) => {
@@ -29,7 +35,8 @@ _dataReady.then(([, ALERTS]) => {
     const d = new Date(iso);
     if (isNaN(d)) return null;
     const p = (n) => (n < 10 ? '0' + n : '' + n);
-    return `${p(d.getDate())}/${p(d.getMonth() + 1)}/${d.getFullYear()} ${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`;
+    const tz = d.toLocaleTimeString('fr-FR', { timeZoneName: 'short' }).split(' ').pop();
+    return `${p(d.getDate())}/${p(d.getMonth() + 1)}/${d.getFullYear()} ${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())} (${tz})`;
   };
   const evalStr = fmtEval(lastEval);
   const evalHtml = evalStr
@@ -207,10 +214,12 @@ _dataReady.then(async ([RAW_DATA]) => {
     lastMode = '';
 
   const pad2 = (n) => (n < 10 ? '0' + n : '' + n);
+  const tzAbbr = new Date().toLocaleTimeString('fr-FR', { timeZoneName: 'short' }).split(' ').pop();
   const fmtDate = (t) => {
     const d = new Date(t);
     return `${pad2(d.getDate())}/${pad2(d.getMonth() + 1)} ${pad2(d.getHours())}:${pad2(d.getMinutes())}`;
   };
+  const fmtDateTz = (t) => `${fmtDate(t)} ${tzAbbr}`;
   const fmtSpd = (v) =>
     v >= 1000
       ? `${(v / 1000).toFixed(1)}<span class="u">Gb/s</span>`
@@ -278,6 +287,13 @@ _dataReady.then(async ([RAW_DATA]) => {
     },
     grid: { color: '#1e2228' },
     ticks: { font: { family: mono, size: 10 }, maxTicksLimit: 12 },
+    title: {
+      display: true,
+      text: `Heure (${tzAbbr})`,
+      font: { family: mono, size: 10 },
+      color: '#666',
+      padding: { top: 2 },
+    },
   };
   const baseOpts = (ar) => ({
     responsive: true,
@@ -562,7 +578,7 @@ _dataReady.then(async ([RAW_DATA]) => {
         piMed = medianOf(piSorted);
       const piP95 = pctOf(piSorted, 95);
 
-      const trLabel = `${fmtDate(rangeStart)} \u2192 ${fmtDate(rangeEnd)}`;
+      const trLabel = `${fmtDateTz(rangeStart)} \u2192 ${fmtDateTz(rangeEnd)}`;
 
       statsEl.innerHTML =
         statCard(
@@ -658,7 +674,7 @@ _dataReady.then(async ([RAW_DATA]) => {
     piChart.options.scales.x.max = rangeEnd;
 
     document.getElementById('rangeLabel').textContent =
-      `${fmtDate(rangeStart)}  \u2192  ${fmtDate(rangeEnd)}`;
+      `${fmtDateTz(rangeStart)}  \u2192  ${fmtDateTz(rangeEnd)}`;
     document
       .querySelectorAll('.rb')
       .forEach((b) => b.classList.toggle('on', parseInt(b.dataset.hours) === currentH));

--- a/scripts/render-template.py
+++ b/scripts/render-template.py
@@ -42,8 +42,10 @@ def main():
     with open(template_path) as f:
         html = f.read()
 
-    now = datetime.now(tz=TZ).strftime("%d/%m/%Y %H:%M")
-    gen = datetime.now(tz=TZ).strftime("%d/%m/%Y à %H:%M:%S")
+    dt = datetime.now(tz=TZ)
+    tz_abbr = dt.strftime("%Z")  # CET or CEST
+    now = dt.strftime(f"%d/%m/%Y %H:%M ({tz_abbr})")
+    gen = dt.strftime(f"%d/%m/%Y à %H:%M:%S ({tz_abbr})")
     if suffix:
         gen = f"{gen} {suffix}"
 


### PR DESCRIPTION
## Changes

### UI fixes (commit 1)
- **Timezone on all timestamps**: append TZ abbreviation (CET/CEST) to server-rendered timestamps (`render-template.py`) and browser-side alert evaluation time (`app.js`)
- **Remove duplicate threshold**: `(threshold: 70.00 °C / 70°C)` → `(threshold: 70.00 °C)` via regex in `fixTemp()`

### Documentation (commit 2)
- **gh-pages deployment analysis**: documents the conflict between RPI systemd timer (git push) and CI workflow (Actions Pages API), with open questions for resolution

## Testing
- 12/12 E2E tests passing (pre-push hooks)