### PR TITLE
feat: backup restore and verification tooling

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Install system dependencies
         run: |
           sudo apt-get update -qq

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Backups
 backups/
+backups-rpi/
 
 # Environment (contains secrets)
 .env

--- a/Justfile
+++ b/Justfile
@@ -104,6 +104,10 @@ last-results n="5":
 backup:
     bash scripts/backup.sh
 
+# Offline integrity check on a backup dir (no stack needed)
+backup-check dir:
+    bash scripts/backup-check.sh {{ dir }}
+
 # ── Build ───────────────────────────────────────────────
 
 # Rebuild speedtest image from scratch (no cache)
@@ -294,6 +298,46 @@ sim-stats:
     @echo "── Data Counts ──"
     @printf "  Speedtest points: %s\n" "$({{ CONTAINER_CLI }} exec rpi-sim-influxdb influx -username admin -password simpass -execute 'SELECT COUNT(download_bandwidth) FROM speedtest' -database speedtest 2>/dev/null | tail -1 | awk '{print $2}')"
     @printf "  Telegraf cpu (last 1h): %s\n" "$({{ CONTAINER_CLI }} exec rpi-sim-influxdb influx -username admin -password simpass -execute 'SELECT COUNT(usage_idle) FROM cpu WHERE time > now() - 1h' -database telegraf 2>/dev/null | tail -1 | awk '{print $2}')"
+
+# Restore an RPi backup into the sim stack (e.g. just sim-restore-backup backups-rpi/20260416-205640)
+sim-restore-backup dir:
+    bash scripts/sim-restore-backup.sh {{ dir }}
+
+# Verify that restored backup data is intact and exploitable
+sim-verify-backup:
+    bash scripts/sim-verify-backup.sh
+
+# Full backup test: nuke sim, restart, restore, verify (e.g. just sim-test-backup backups-rpi/20260416-205640)
+sim-test-backup dir:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "── Step 0/5: Offline integrity check ──"
+    bash scripts/backup-check.sh {{ dir }}
+    echo ""
+    echo "── Step 1/5: Nuke sim stack ──"
+    {{ sim_compose }} down -v 2>/dev/null || true
+    echo ""
+    echo "── Step 2/5: Start fresh sim stack ──"
+    {{ sim_compose }} up -d
+    echo ""
+    echo "── Step 3/5: Wait for InfluxDB healthy ──"
+    for i in $(seq 1 60); do
+        if curl -sf "http://localhost:8086/ping" >/dev/null 2>&1; then
+            echo "  ✅ InfluxDB healthy after ~$((i * 5))s"
+            break
+        fi
+        if [[ "$i" -eq 60 ]]; then
+            echo "  ❌ InfluxDB not healthy after 300s"
+            exit 1
+        fi
+        sleep 5
+    done
+    echo ""
+    echo "── Step 4/5: Restore ──"
+    bash scripts/sim-restore-backup.sh {{ dir }}
+    echo ""
+    echo "── Step 5/5: Verify ──"
+    bash scripts/sim-verify-backup.sh
 
 # Register QEMU user-static (needed once per host reboot)
 sim-binfmt:

--- a/Justfile
+++ b/Justfile
@@ -100,9 +100,26 @@ last-results n="5":
 
 # ── Backup & Restore ───────────────────────────────────
 
-# Create a full backup (dashboards + InfluxDB)
+# Create a full backup (dashboards + InfluxDB) with rotation (keep BACKUP_KEEP, default 5)
 backup:
     bash scripts/backup.sh
+
+# Rotate old backups, keeping the N most recent (default 5, override with BACKUP_KEEP=N)
+backup-rotate keep="5":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    root="backups"
+    mapfile -t all < <(find "$root" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort -r)
+    echo "Found ${#all[@]} backup(s), keeping {{ keep }}"
+    if [[ ${#all[@]} -gt {{ keep }} ]]; then
+        for old in "${all[@]:{{ keep }}}"; do
+            echo "  🗑  Removing $old"
+            rm -rf "${root:?}/$old"
+        done
+        echo "Pruned $(( ${#all[@]} - {{ keep }} )) old backup(s)"
+    else
+        echo "Nothing to prune"
+    fi
 
 # Offline integrity check on a backup dir (no stack needed)
 backup-check dir:

--- a/Justfile
+++ b/Justfile
@@ -106,20 +106,7 @@ backup:
 
 # Rotate old backups, keeping the N most recent (default 5, override with BACKUP_KEEP=N)
 backup-rotate keep="5":
-    #!/usr/bin/env bash
-    set -euo pipefail
-    root="backups"
-    mapfile -t all < <(find "$root" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort -r)
-    echo "Found ${#all[@]} backup(s), keeping {{ keep }}"
-    if [[ ${#all[@]} -gt {{ keep }} ]]; then
-        for old in "${all[@]:{{ keep }}}"; do
-            echo "  🗑  Removing $old"
-            rm -rf "${root:?}/$old"
-        done
-        echo "Pruned $(( ${#all[@]} - {{ keep }} )) old backup(s)"
-    else
-        echo "Nothing to prune"
-    fi
+    bash scripts/backup-rotate.sh {{ keep }}
 
 # Offline integrity check on a backup dir (no stack needed)
 backup-check dir:

--- a/README.md
+++ b/README.md
@@ -100,11 +100,12 @@ just install-timers
 
 ### Data
 
-| Commande                | Description                                    |
-| ----------------------- | ---------------------------------------------- |
-| `just speedtest`        | Lancer un speedtest manuellement (hors cron)   |
-| `just last-results [N]` | Derniers N résultats speedtest (défaut: 5)     |
-| `just backup`           | Backup complet : dashboards Grafana + InfluxDB |
+| Commande                  | Description                                    |
+| ------------------------- | ---------------------------------------------- |
+| `just speedtest`          | Lancer un speedtest manuellement (hors cron)   |
+| `just last-results [N]`   | Derniers N résultats speedtest (défaut: 5)     |
+| `just backup`             | Backup complet : dashboards Grafana + InfluxDB |
+| `just backup-check <dir>` | Vérification intégrité offline (gzip -t, JSON) |
 
 ### Build & Cleanup
 
@@ -152,19 +153,22 @@ Les timers remplacent le crontab : la configuration est versionnée dans `system
 
 Stack de simulation locale : tous les containers tournent en ARM64 via QEMU, reproduisant l'architecture du RPi4 de production. Voir [docs/sim-environment.md](docs/sim-environment.md) pour le détail complet.
 
-| Commande             | Description                                         |
-| -------------------- | --------------------------------------------------- |
-| `just sim-binfmt`    | Enregistrer les handlers QEMU (1× par reboot)       |
-| `just sim-up`        | Démarrer la stack sim complète                      |
-| `just sim-stop`      | Arrêter (préserve l'état)                           |
-| `just sim-down`      | Supprimer les containers (préserve les volumes)     |
-| `just sim-nuke`      | Supprimer containers **et** volumes (⚠️ destructif) |
-| `just sim-status`    | État des containers + health checks                 |
-| `just sim-logs`      | Dernières 50 lignes de logs                         |
-| `just sim-build`     | Build l'image speedtest pour ARM64                  |
-| `just sim-speedtest` | Lancer un speedtest manuellement                    |
-| `just sim-test`      | Suite de smoke tests (25 checks)                    |
-| `just sim-stats`     | Bases de données, rétention, compteurs              |
+| Commande                        | Description                                         |
+| ------------------------------- | --------------------------------------------------- |
+| `just sim-binfmt`               | Enregistrer les handlers QEMU (1× par reboot)       |
+| `just sim-up`                   | Démarrer la stack sim complète                      |
+| `just sim-stop`                 | Arrêter (préserve l'état)                           |
+| `just sim-down`                 | Supprimer les containers (préserve les volumes)     |
+| `just sim-nuke`                 | Supprimer containers **et** volumes (⚠️ destructif) |
+| `just sim-status`               | État des containers + health checks                 |
+| `just sim-logs`                 | Dernières 50 lignes de logs                         |
+| `just sim-build`                | Build l'image speedtest pour ARM64                  |
+| `just sim-speedtest`            | Lancer un speedtest manuellement                    |
+| `just sim-test`                 | Suite de smoke tests (25 checks)                    |
+| `just sim-stats`                | Bases de données, rétention, compteurs              |
+| `just sim-restore-backup <dir>` | Restaurer un backup RPi dans la sim                 |
+| `just sim-verify-backup`        | Vérifier l'intégrité des données restaurées         |
+| `just sim-test-backup <dir>`    | Pipeline complet : nuke → restore → verify          |
 
 Grafana : <http://localhost:3000> (admin / simpass) — Chronograf : <http://localhost:8888>
 
@@ -229,6 +233,22 @@ Visibles dans Grafana → Alerting → Alert rules, ou via `just alerts`.
 
 ```bash
 just backup    # Crée un dossier horodaté dans backups/ avec dashboards + InfluxDB
+```
+
+### Validation et restauration
+
+Outils pour vérifier et restaurer des backups RPi dans la stack sim locale. Voir [docs/backup-restore-tooling.md](docs/backup-restore-tooling.md) pour le détail complet.
+
+```bash
+# Vérification offline (pas besoin de stack)
+just backup-check backups-rpi/20260416-205640
+
+# Restauration dans la sim
+just sim-restore-backup backups-rpi/20260416-205640
+just sim-verify-backup
+
+# Pipeline complet (nuke + start + check + restore + verify)
+just sim-test-backup backups-rpi/20260416-205640
 ```
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -100,12 +100,13 @@ just install-timers
 
 ### Data
 
-| Commande                  | Description                                    |
-| ------------------------- | ---------------------------------------------- |
-| `just speedtest`          | Lancer un speedtest manuellement (hors cron)   |
-| `just last-results [N]`   | Derniers N résultats speedtest (défaut: 5)     |
-| `just backup`             | Backup complet : dashboards Grafana + InfluxDB |
-| `just backup-check <dir>` | Vérification intégrité offline (gzip -t, JSON) |
+| Commande                  | Description                                               |
+| ------------------------- | --------------------------------------------------------- |
+| `just speedtest`          | Lancer un speedtest manuellement (hors cron)              |
+| `just last-results [N]`   | Derniers N résultats speedtest (défaut: 5)                |
+| `just backup`             | Backup complet + rotation auto (garde les 5 derniers)     |
+| `just backup-rotate [N]`  | Rotation manuelle : garder les N plus récents (défaut: 5) |
+| `just backup-check <dir>` | Vérification intégrité offline (gzip -t, JSON)            |
 
 ### Build & Cleanup
 
@@ -233,6 +234,10 @@ Visibles dans Grafana → Alerting → Alert rules, ou via `just alerts`.
 
 ```bash
 just backup    # Crée un dossier horodaté dans backups/ avec dashboards + InfluxDB
+               # + rotation automatique (garde les 5 derniers, configurable via BACKUP_KEEP)
+
+just backup-rotate      # Rotation manuelle (garde 5)
+just backup-rotate 3    # Rotation manuelle (garde 3)
 ```
 
 ### Validation et restauration

--- a/docs/backup-restore-tooling.md
+++ b/docs/backup-restore-tooling.md
@@ -36,6 +36,8 @@ backups-rpi/
 
 | Recipe                          | Stack needed | Description                                            |
 | ------------------------------- | ------------ | ------------------------------------------------------ |
+| `just backup`                   | yes          | Full backup + automatic rotation (keep last 5)         |
+| `just backup-rotate [N]`        | no           | Standalone rotation: keep N most recent (default 5)    |
 | `just backup-check <dir>`       | no           | Offline integrity: gzip -t on all shards, JSON valid   |
 | `just sim-restore-backup <dir>` | yes          | Drop DBs, restore InfluxDB, import dashboards          |
 | `just sim-verify-backup`        | yes          | 10 checks: counts, date range, Grafana connectivity    |
@@ -45,6 +47,7 @@ backups-rpi/
 
 | Script                          | Purpose                                            |
 | ------------------------------- | -------------------------------------------------- |
+| `scripts/backup.sh`             | Full backup + automatic rotation                   |
 | `scripts/backup-check.sh`       | Offline validation (manifest, meta, gzip -t, JSON) |
 | `scripts/sim-restore-backup.sh` | Restore backup into running sim stack              |
 | `scripts/sim-verify-backup.sh`  | Verify restored data integrity and Grafana state   |
@@ -128,6 +131,23 @@ is `InfluxDB-Speedtest` (database: `speedtest`). In the sim stack, the
 default is `InfluxDB` (database: `telegraf`), causing "No data" in dashboards.
 
 The restore script automatically patches these panels during import.
+
+## Backup rotation
+
+Rotation is built into `scripts/backup.sh` and runs automatically after
+each backup. The `BACKUP_KEEP` environment variable controls how many
+backups to retain (default: **5**). Older backups are deleted by
+chronological directory name (`YYYYMMDD-HHMMSS`).
+
+```bash
+# Automatic: rotation runs at the end of every backup
+just backup
+
+# Manual: rotate without creating a new backup
+just backup-rotate      # keep 5 (default)
+just backup-rotate 3    # keep 3
+BACKUP_KEEP=10 just backup   # override during backup
+```
 
 ### QEMU query performance
 

--- a/docs/backup-restore-tooling.md
+++ b/docs/backup-restore-tooling.md
@@ -1,0 +1,136 @@
+# Backup Restore Tooling
+
+Automated tools for validating, restoring, and verifying RPi backup
+archives in the local simulation stack. Provides a 3-level verification
+pipeline: offline integrity check → restore into sim → data verification.
+
+## Overview
+
+```
+backups-rpi/
+  20260416-205640/                ← rsync'd from RPi
+    influxdb-backup/              ← InfluxDB portable dump
+      *.manifest, *.meta, *.tar.gz
+    dashboard-*.json              ← Grafana dashboard exports
+    datasources.json              ← Grafana datasource config
+
+                    ┌──────────────────────────┐
+                    │ just backup-check <dir>   │  Level 1: Offline
+                    │ (no stack needed)         │  gzip -t, JSON, manifest
+                    └──────────┬───────────────┘
+                               │
+                    ┌──────────▼───────────────┐
+                    │ just sim-restore-backup   │  Level 2: Restore
+                    │ <dir>                     │  influxd restore + dashboards
+                    └──────────┬───────────────┘
+                               │
+                    ┌──────────▼───────────────┐
+                    │ just sim-verify-backup    │  Level 3: Data verification
+                    │                           │  counts, dates, Grafana
+                    └──────────────────────────┘
+
+    just sim-test-backup <dir>   ← runs all 3 levels end-to-end
+```
+
+## Justfile recipes
+
+| Recipe                          | Stack needed | Description                                            |
+| ------------------------------- | ------------ | ------------------------------------------------------ |
+| `just backup-check <dir>`       | no           | Offline integrity: gzip -t on all shards, JSON valid   |
+| `just sim-restore-backup <dir>` | yes          | Drop DBs, restore InfluxDB, import dashboards          |
+| `just sim-verify-backup`        | yes          | 10 checks: counts, date range, Grafana connectivity    |
+| `just sim-test-backup <dir>`    | auto         | Full pipeline: nuke → start → check → restore → verify |
+
+## Scripts
+
+| Script                          | Purpose                                            |
+| ------------------------------- | -------------------------------------------------- |
+| `scripts/backup-check.sh`       | Offline validation (manifest, meta, gzip -t, JSON) |
+| `scripts/sim-restore-backup.sh` | Restore backup into running sim stack              |
+| `scripts/sim-verify-backup.sh`  | Verify restored data integrity and Grafana state   |
+
+## Level 1 — Offline integrity check (`backup-check`)
+
+Validates a backup directory without needing any running stack. Checks:
+
+1. **Directory structure**: `influxdb-backup/` exists
+2. **Manifest & meta**: present and non-empty
+3. **Shard archives**: every `.tar.gz` passes `gzip -t` (detects truncated/corrupt files from interrupted rsync)
+4. **Dashboard JSON**: valid JSON with `.dashboard` key
+5. **Datasources JSON**: valid JSON, datasource count
+6. **Size sanity**: warns if backup is suspiciously small (<1 MB)
+
+```bash
+just backup-check backups-rpi/20260416-205640
+# 🟢 VERDICT: Backup structure is INTACT — safe to restore.
+```
+
+## Level 2 — Restore (`sim-restore-backup`)
+
+Restores an RPi backup into the running sim stack:
+
+1. Validates backup directory structure
+2. Checks sim stack is running and InfluxDB is healthy
+3. Drops existing `speedtest` and `telegraf` databases
+4. Copies `influxdb-backup/` into the InfluxDB container
+5. Runs `influxd restore -portable`
+6. Re-grants permissions to the `telegraf` user
+7. Imports Grafana dashboards with **datasource fix**: panels with
+   `datasource: null` and `measurement == "speedtest"` are patched
+   to use the explicit `influxdb-speedtest` datasource UID (prevents
+   the "No data" issue caused by Grafana's default pointing to telegraf)
+
+```bash
+just sim-up                                        # if not running
+just sim-restore-backup backups-rpi/20260416-205640
+```
+
+## Level 3 — Data verification (`sim-verify-backup`)
+
+Post-restore validation with 10 checks:
+
+1. Databases `speedtest` and `telegraf` exist
+2. `download_bandwidth` count (expected >100k for full production backup)
+3. First measurement date (expected 2022)
+4. Last measurement date (expected 2026)
+5. Telegraf measurements present
+6. Grafana datasource connectivity (2 datasources)
+7. Grafana dashboard count and listing
+
+```bash
+just sim-verify-backup
+# 🟢 VERDICT: Backup is EXPLOITABLE — data restored successfully.
+```
+
+## Full pipeline (`sim-test-backup`)
+
+Runs all 3 levels end-to-end with a fresh sim stack:
+
+```bash
+just sim-test-backup backups-rpi/20260416-205640
+```
+
+Pipeline steps: 0. Offline integrity check (fails fast if backup is corrupt)
+
+1. Nuke existing sim stack (`docker compose down -v`)
+2. Start fresh sim stack
+3. Wait for InfluxDB healthy
+4. Restore backup
+5. Verify data integrity
+
+## Known issues
+
+### Datasource null in RPi dashboards
+
+RPi Grafana dashboards may have `datasource: null` on speedtest panels,
+meaning they use the Grafana default datasource. In production, the default
+is `InfluxDB-Speedtest` (database: `speedtest`). In the sim stack, the
+default is `InfluxDB` (database: `telegraf`), causing "No data" in dashboards.
+
+The restore script automatically patches these panels during import.
+
+### QEMU query performance
+
+COUNT/ORDER BY queries on 120k+ points through ARM64 QEMU emulation can
+take 30-60 seconds. The verify script uses the InfluxDB HTTP API directly
+(not the emulated `influx` CLI) for better performance.

--- a/scripts/backup-check.sh
+++ b/scripts/backup-check.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# Offline integrity check for an RPi backup directory.
+# Validates archive integrity WITHOUT needing the sim stack running.
+#
+# Usage: bash scripts/backup-check.sh <backup-dir>
+#   e.g.: bash scripts/backup-check.sh backups-rpi/20260416-205640
+#
+# Checks:
+#   1. Directory structure (influxdb-backup/, manifest, meta)
+#   2. Every .tar.gz referenced in the manifest exists and is not corrupt (gzip -t)
+#   3. Dashboard JSON files are valid JSON
+#   4. Datasources JSON is valid JSON
+#   5. Meta file is non-empty and parseable
+set -uo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <backup-dir>"
+    echo "  e.g.: $0 backups-rpi/20260416-205640"
+    exit 1
+fi
+
+BACKUP_DIR="$1"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Resolve relative paths from project root
+if [[ ! "$BACKUP_DIR" = /* ]]; then
+    BACKUP_DIR="$PROJECT_DIR/$BACKUP_DIR"
+fi
+
+PASS=0
+FAIL=0
+WARN=0
+
+pass() {
+    echo "  ✅ $1"
+    ((PASS++))
+}
+fail() {
+    echo "  ❌ $1"
+    ((FAIL++))
+}
+warn() {
+    echo "  ⚠️  $1"
+    ((WARN++))
+}
+
+echo "╔══════════════════════════════════════════════════════════╗"
+echo "║     Backup Integrity Check (offline)                     ║"
+echo "║     $(date -Iseconds)                       ║"
+echo "╚══════════════════════════════════════════════════════════╝"
+echo ""
+echo "  Target: $BACKUP_DIR"
+echo ""
+
+# ── 1. Directory structure ────────────────────────────────
+echo "── 1. Directory structure ──"
+
+if [[ ! -d "$BACKUP_DIR" ]]; then
+    fail "Directory not found: $BACKUP_DIR"
+    echo ""
+    echo "🔴 VERDICT: Backup directory does not exist."
+    exit 1
+fi
+pass "Backup directory exists"
+
+INFLUX_DIR="$BACKUP_DIR/influxdb-backup"
+if [[ ! -d "$INFLUX_DIR" ]]; then
+    fail "influxdb-backup/ subdirectory missing"
+else
+    pass "influxdb-backup/ directory present"
+fi
+echo ""
+
+# ── 2. Manifest & meta ───────────────────────────────────
+echo "── 2. Manifest & meta files ──"
+
+mapfile -t MANIFESTS < <(find "$INFLUX_DIR" -name '*.manifest' 2>/dev/null)
+if [[ ${#MANIFESTS[@]} -eq 0 ]]; then
+    fail "No .manifest file found in influxdb-backup/"
+else
+    for m in "${MANIFESTS[@]}"; do
+        if [[ -s "$m" ]]; then
+            pass "Manifest: $(basename "$m") ($(wc -c <"$m") bytes)"
+        else
+            fail "Manifest is empty: $(basename "$m")"
+        fi
+    done
+fi
+
+mapfile -t METAS < <(find "$INFLUX_DIR" -name '*.meta' 2>/dev/null)
+if [[ ${#METAS[@]} -eq 0 ]]; then
+    fail "No .meta file found in influxdb-backup/"
+else
+    for m in "${METAS[@]}"; do
+        if [[ -s "$m" ]]; then
+            pass "Meta: $(basename "$m") ($(wc -c <"$m") bytes)"
+        else
+            fail "Meta file is empty: $(basename "$m")"
+        fi
+    done
+fi
+echo ""
+
+# ── 3. Shard archives integrity ──────────────────────────
+echo "── 3. Shard archives (gzip -t) ──"
+
+mapfile -t SHARDS < <(find "$INFLUX_DIR" -name '*.tar.gz' 2>/dev/null | sort)
+SHARD_COUNT=${#SHARDS[@]}
+
+if [[ "$SHARD_COUNT" -eq 0 ]]; then
+    fail "No .tar.gz shard files found"
+else
+    echo "  📦 Found $SHARD_COUNT shard archive(s) — testing each..."
+    CORRUPT=0
+    for shard in "${SHARDS[@]}"; do
+        if ! gzip -t "$shard" 2>/dev/null; then
+            fail "CORRUPT: $(basename "$shard")"
+            ((CORRUPT++))
+        fi
+    done
+    if [[ "$CORRUPT" -eq 0 ]]; then
+        pass "All $SHARD_COUNT shard archives pass gzip integrity check"
+    else
+        fail "$CORRUPT/$SHARD_COUNT shard(s) are corrupt"
+    fi
+fi
+echo ""
+
+# ── 4. Dashboard JSON validation ─────────────────────────
+echo "── 4. Dashboard JSON files ──"
+
+mapfile -t DASHBOARDS < <(find "$BACKUP_DIR" -maxdepth 1 -name 'dashboard-*.json' 2>/dev/null | sort)
+DASH_COUNT=${#DASHBOARDS[@]}
+
+if [[ "$DASH_COUNT" -eq 0 ]]; then
+    warn "No dashboard-*.json files found (may be normal for InfluxDB-only backups)"
+else
+    INVALID_JSON=0
+    for f in "${DASHBOARDS[@]}"; do
+        NAME=$(basename "$f")
+        if ! jq empty "$f" 2>/dev/null; then
+            fail "Invalid JSON: $NAME"
+            ((INVALID_JSON++))
+        else
+            # Check for expected structure
+            if jq -e '.dashboard' "$f" >/dev/null 2>&1; then
+                TITLE=$(jq -r '.dashboard.title // "untitled"' "$f")
+                pass "$NAME → \"$TITLE\""
+            else
+                warn "$NAME is valid JSON but missing .dashboard key"
+            fi
+        fi
+    done
+fi
+echo ""
+
+# ── 5. Datasources JSON ──────────────────────────────────
+echo "── 5. Datasources file ──"
+
+DS_FILE="$BACKUP_DIR/datasources.json"
+if [[ ! -f "$DS_FILE" ]]; then
+    warn "datasources.json not found (may be normal for InfluxDB-only backups)"
+else
+    if ! jq empty "$DS_FILE" 2>/dev/null; then
+        fail "datasources.json is invalid JSON"
+    else
+        DS_COUNT=$(jq 'length' "$DS_FILE" 2>/dev/null || echo 0)
+        pass "datasources.json is valid ($DS_COUNT datasource(s))"
+    fi
+fi
+echo ""
+
+# ── 6. Size sanity check ─────────────────────────────────
+echo "── 6. Size sanity ──"
+
+TOTAL_SIZE=$(du -sb "$BACKUP_DIR" | awk '{print $1}')
+TOTAL_HUMAN=$(du -sh "$BACKUP_DIR" | awk '{print $1}')
+echo "  📊 Total backup size: $TOTAL_HUMAN"
+
+# A valid backup with ~122k speedtest points + telegraf should be at least ~10MB
+if [[ "$TOTAL_SIZE" -lt 1048576 ]]; then
+    warn "Backup is suspiciously small (<1MB) — may be incomplete"
+elif [[ "$TOTAL_SIZE" -lt 10485760 ]]; then
+    warn "Backup is relatively small (<10MB) — verify data completeness after restore"
+else
+    pass "Backup size looks reasonable ($TOTAL_HUMAN)"
+fi
+echo ""
+
+# ── Summary ──────────────────────────────────────────────
+echo "╔══════════════════════════════════════════════════════════╗"
+printf "║  Results: ✅ %-3d passed  ❌ %-3d failed  ⚠️  %-3d warnings ║\n" "$PASS" "$FAIL" "$WARN"
+echo "╚══════════════════════════════════════════════════════════╝"
+echo ""
+
+if [[ "$FAIL" -eq 0 ]]; then
+    echo "🟢 VERDICT: Backup structure is INTACT — safe to restore."
+    exit 0
+else
+    echo "🔴 VERDICT: Backup has $FAIL INTEGRITY ISSUE(S) — do NOT restore."
+    exit 1
+fi

--- a/scripts/backup-rotate.sh
+++ b/scripts/backup-rotate.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Rotate old backups, keeping the N most recent.
+# Usage: backup-rotate.sh [N]  (default: 5)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BACKUPS_ROOT="$SCRIPT_DIR/backups"
+KEEP="${1:-5}"
+
+mapfile -t ALL < <(find "$BACKUPS_ROOT" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort -r)
+echo "Found ${#ALL[@]} backup(s), keeping $KEEP"
+
+if [[ ${#ALL[@]} -gt $KEEP ]]; then
+    for old in "${ALL[@]:$KEEP}"; do
+        echo "  🗑  Removing $old"
+        rm -rf "${BACKUPS_ROOT:?}/$old"
+    done
+    echo "Pruned $((${#ALL[@]} - KEEP)) old backup(s)"
+else
+    echo "Nothing to prune"
+fi

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -5,7 +5,9 @@ set -euo pipefail
 DOCKER=${CONTAINER_CLI:-$(command -v podman >/dev/null 2>&1 && echo podman || echo docker)}
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-BACKUP_DIR="$SCRIPT_DIR/backups/$(date +%Y%m%d-%H%M%S)"
+BACKUPS_ROOT="$SCRIPT_DIR/backups"
+BACKUP_DIR="$BACKUPS_ROOT/$(date +%Y%m%d-%H%M%S)"
+BACKUP_KEEP="${BACKUP_KEEP:-5}"
 mkdir -p "$BACKUP_DIR"
 
 # Load credentials: prefer env vars (set by Justfile dotenv-load), fallback to .env file
@@ -55,3 +57,19 @@ echo "── Summary ──"
 echo "  Location: $BACKUP_DIR"
 echo "  Total:    $(du -sh "$BACKUP_DIR" | awk '{print $1}')"
 ls -lh "$BACKUP_DIR/"
+
+# ── Rotation ──
+# Keep the N most recent backups (BACKUP_KEEP, default 5), remove older ones.
+mapfile -t ALL_BACKUPS < <(find "$BACKUPS_ROOT" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort -r)
+if [[ ${#ALL_BACKUPS[@]} -gt $BACKUP_KEEP ]]; then
+    echo ""
+    echo "── Rotation (keeping $BACKUP_KEEP most recent) ──"
+    for old in "${ALL_BACKUPS[@]:$BACKUP_KEEP}"; do
+        echo "  🗑  Removing $old"
+        rm -rf "${BACKUPS_ROOT:?}/$old"
+    done
+    echo "  Pruned $((${#ALL_BACKUPS[@]} - BACKUP_KEEP)) old backup(s)"
+else
+    echo ""
+    echo "── Rotation: ${#ALL_BACKUPS[@]}/$BACKUP_KEEP slots used, nothing to prune ──"
+fi

--- a/scripts/sim-restore-backup.sh
+++ b/scripts/sim-restore-backup.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# Restore an RPi backup into the running sim stack.
+#
+# Usage: bash scripts/sim-restore-backup.sh <backup-dir>
+#   e.g.: bash scripts/sim-restore-backup.sh backups-rpi/20260416-205640
+#
+# Prerequisites:
+#   - Sim stack must be running (`just sim-up`) with InfluxDB healthy
+#   - Backup dir must contain influxdb-backup/ and optionally dashboard-*.json
+#
+# What it does:
+#   1. Validates the backup directory structure
+#   2. Drops existing speedtest/telegraf databases in sim InfluxDB
+#   3. Copies influxdb-backup/ into the container
+#   4. Runs `influxd restore -portable` to restore both databases
+#   5. Re-grants permissions to the telegraf user
+#   6. Optionally imports Grafana dashboards from the backup
+set -euo pipefail
+
+# ── CLI ──────────────────────────────────────────────────
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <backup-dir>"
+    echo "  e.g.: $0 backups-rpi/20260416-205640"
+    exit 1
+fi
+
+BACKUP_DIR="$1"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Resolve relative paths from project root
+if [[ ! "$BACKUP_DIR" = /* ]]; then
+    BACKUP_DIR="$PROJECT_DIR/$BACKUP_DIR"
+fi
+
+# ── Detect container CLI ─────────────────────────────────
+if [[ -n "${CONTAINER_CLI:-}" ]]; then
+    DOCKER="$CONTAINER_CLI"
+elif command -v docker >/dev/null 2>&1; then
+    DOCKER=docker
+elif command -v podman >/dev/null 2>&1; then
+    DOCKER=podman
+else
+    DOCKER=docker
+fi
+
+INFLUX_CONTAINER="rpi-sim-influxdb"
+
+# ── Read sim credentials ─────────────────────────────────
+ENV_FILE="$PROJECT_DIR/sim/.env.sim"
+_read_env() { grep "^$1=" "$ENV_FILE" | cut -d= -f2- | sed "s/^['\"]//;s/['\"]$//"; }
+INFLUX_USER=$(_read_env INFLUXDB_ADMIN_USER)
+INFLUX_PASS=$(_read_env INFLUXDB_ADMIN_PASSWORD)
+GRAFANA_USER=$(_read_env GF_SECURITY_ADMIN_USER)
+GRAFANA_PASS=$(_read_env GF_SECURITY_ADMIN_PASSWORD)
+GRAFANA_CREDS="${GRAFANA_USER:-admin}:${GRAFANA_PASS}"
+GRAFANA_URL="http://localhost:3000"
+_gcurl() { curl -sf -K <(printf 'user = "%s"\n' "$GRAFANA_CREDS") "$@"; }
+
+echo "╔══════════════════════════════════════════════════════════╗"
+echo "║     Sim Stack — Restore RPi Backup                       ║"
+echo "║     $(date -Iseconds)                       ║"
+echo "╚══════════════════════════════════════════════════════════╝"
+echo ""
+
+# ── 1. Validate backup dir ───────────────────────────────
+echo "── 1. Validate backup ──"
+if [[ ! -d "$BACKUP_DIR" ]]; then
+    echo "  ❌ Directory not found: $BACKUP_DIR"
+    exit 1
+fi
+if [[ ! -d "$BACKUP_DIR/influxdb-backup" ]]; then
+    echo "  ❌ No influxdb-backup/ subdirectory in $BACKUP_DIR"
+    exit 1
+fi
+MANIFEST_COUNT=$(find "$BACKUP_DIR/influxdb-backup" -name '*.manifest' | wc -l)
+SHARD_COUNT=$(find "$BACKUP_DIR/influxdb-backup" -name '*.tar.gz' | wc -l)
+echo "  ✅ Backup dir: $BACKUP_DIR"
+echo "     Manifests: $MANIFEST_COUNT, Shards: $SHARD_COUNT"
+
+DASHBOARD_COUNT=$(find "$BACKUP_DIR" -maxdepth 1 -name 'dashboard-*.json' | wc -l)
+if [[ "$DASHBOARD_COUNT" -gt 0 ]]; then
+    echo "     Dashboards: $DASHBOARD_COUNT JSON files"
+fi
+
+# ── 2. Check sim stack is running ────────────────────────
+echo ""
+echo "── 2. Check sim stack ──"
+if ! "$DOCKER" inspect --format '{{.State.Running}}' "$INFLUX_CONTAINER" 2>/dev/null | grep -q 'true'; then
+    echo "  ❌ Container $INFLUX_CONTAINER is not running. Run 'just sim-up' first."
+    exit 1
+fi
+echo "  ✅ $INFLUX_CONTAINER is running"
+
+# Wait for InfluxDB to be healthy (up to 60s for already-running stack)
+echo "  ⏳ Waiting for InfluxDB to be healthy..."
+for i in $(seq 1 12); do
+    if curl -sf "http://localhost:8086/ping" >/dev/null 2>&1; then
+        echo "  ✅ InfluxDB is healthy"
+        break
+    fi
+    if [[ "$i" -eq 12 ]]; then
+        echo "  ❌ InfluxDB not healthy after 60s"
+        exit 1
+    fi
+    sleep 5
+done
+
+# ── 3. Drop existing databases ───────────────────────────
+echo ""
+echo "── 3. Drop existing databases ──"
+for db in speedtest telegraf; do
+    curl -sf -XPOST "http://localhost:8086/query?u=${INFLUX_USER}&p=${INFLUX_PASS}" \
+        --data-urlencode "q=DROP DATABASE $db" >/dev/null 2>&1 || true
+    echo "  → Dropped '$db' (if existed)"
+done
+
+# ── 4. Copy backup into container ────────────────────────
+echo ""
+echo "── 4. Copy backup into container ──"
+"$DOCKER" exec "$INFLUX_CONTAINER" rm -rf /tmp/influxdb-restore 2>/dev/null || true
+"$DOCKER" cp "$BACKUP_DIR/influxdb-backup" "$INFLUX_CONTAINER:/tmp/influxdb-restore"
+echo "  ✅ Copied influxdb-backup/ → $INFLUX_CONTAINER:/tmp/influxdb-restore"
+
+# ── 5. Restore InfluxDB ─────────────────────────────────
+echo ""
+echo "── 5. Restore InfluxDB (portable) ──"
+"$DOCKER" exec "$INFLUX_CONTAINER" influxd restore -portable /tmp/influxdb-restore
+echo "  ✅ influxd restore completed"
+
+# ── 6. Re-grant permissions ──────────────────────────────
+echo ""
+echo "── 6. Re-grant permissions ──"
+for db in speedtest telegraf; do
+    curl -sf -XPOST "http://localhost:8086/query?u=${INFLUX_USER}&p=${INFLUX_PASS}" \
+        --data-urlencode "q=GRANT ALL ON $db TO \"telegraf\"" >/dev/null 2>&1 || true
+    echo "  → GRANT ALL ON $db TO telegraf"
+done
+
+# ── 7. Cleanup temp files in container ───────────────────
+"$DOCKER" exec "$INFLUX_CONTAINER" rm -rf /tmp/influxdb-restore
+
+# ── 8. Import Grafana dashboards (if present) ────────────
+if [[ "$DASHBOARD_COUNT" -gt 0 ]]; then
+    echo ""
+    echo "── 7. Import Grafana dashboards ──"
+
+    # Wait for Grafana to be ready
+    for i in $(seq 1 12); do
+        if _gcurl "$GRAFANA_URL/api/health" 2>/dev/null | jq -e '.database == "ok"' >/dev/null 2>&1; then
+            break
+        fi
+        if [[ "$i" -eq 12 ]]; then
+            echo "  ⚠️  Grafana not ready — skipping dashboard import"
+            DASHBOARD_COUNT=0
+            break
+        fi
+        sleep 5
+    done
+
+    if [[ "$DASHBOARD_COUNT" -gt 0 ]]; then
+        for f in "$BACKUP_DIR"/dashboard-*.json; do
+            TITLE=$(jq -r '.dashboard.title // "unknown"' "$f" 2>/dev/null)
+            # Strip meta fields for import: set id=null.
+            # Fix null datasources on speedtest panels: RPi backups may have
+            # datasource=null (uses Grafana default), but in sim the default
+            # points to telegraf, not speedtest. Patch them to use the explicit
+            # InfluxDB-Speedtest datasource UID.
+            PAYLOAD=$(jq '
+              {
+                dashboard: (
+                  .dashboard
+                  | .id = null
+                  | .panels |= [.[] |
+                      if .targets then
+                        .targets |= [.[] |
+                          if .measurement == "speedtest" and (.datasource == null or .datasource == "")
+                          then .datasource = {"type": "influxdb", "uid": "influxdb-speedtest"}
+                          else . end
+                        ]
+                        | if .datasource == null and any(.targets[]; .measurement == "speedtest")
+                          then .datasource = {"type": "influxdb", "uid": "influxdb-speedtest"}
+                          else . end
+                      else . end
+                    ]
+                ),
+                folderId: 0,
+                overwrite: true
+              }' "$f" 2>/dev/null)
+            if [[ -n "$PAYLOAD" ]]; then
+                RESULT=$(_gcurl -X POST -H "Content-Type: application/json" \
+                    -d "$PAYLOAD" "$GRAFANA_URL/api/dashboards/db" 2>/dev/null || echo '{}')
+                STATUS=$(echo "$RESULT" | jq -r '.status // "error"')
+                if [[ "$STATUS" == "success" ]]; then
+                    echo "  ✅ Imported: $TITLE"
+                else
+                    echo "  ⚠️  Import issue for '$TITLE': $(echo "$RESULT" | jq -r '.message // "unknown"')"
+                fi
+            fi
+        done
+    fi
+fi
+
+echo ""
+echo "── Restore complete ──"
+echo "  Backup: $(basename "$BACKUP_DIR")"
+echo "  Run 'just sim-verify-backup' to validate data integrity."

--- a/scripts/sim-verify-backup.sh
+++ b/scripts/sim-verify-backup.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# Verify that a backup restore in the sim stack produced valid data.
+#
+# Usage: bash scripts/sim-verify-backup.sh
+#
+# Checks:
+#   1. Databases speedtest and telegraf exist
+#   2. Count of download_bandwidth in speedtest (expected ~122 968)
+#   3. First measurement date (expected ~2022-11-25)
+#   4. Last measurement date (expected near backup date)
+#   5. Grafana dashboards are loaded and accessible
+#   6. Grafana datasource connectivity
+#
+# Exit code: 0 if all critical checks pass, 1 otherwise
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ── Detect container CLI ─────────────────────────────────
+# shellcheck disable=SC2034  # DOCKER used by future extensions
+if [[ -n "${CONTAINER_CLI:-}" ]]; then
+    DOCKER="$CONTAINER_CLI"
+elif command -v docker >/dev/null 2>&1; then
+    DOCKER=docker
+elif command -v podman >/dev/null 2>&1; then
+    DOCKER=podman
+else
+    DOCKER=docker
+fi
+
+# shellcheck disable=SC2034  # INFLUX_CONTAINER used by future extensions
+INFLUX_CONTAINER="rpi-sim-influxdb"
+INFLUXDB_URL="http://localhost:8086"
+GRAFANA_URL="http://localhost:3000"
+
+# ── Read sim credentials ─────────────────────────────────
+ENV_FILE="$PROJECT_DIR/sim/.env.sim"
+_read_env() { grep "^$1=" "$ENV_FILE" | cut -d= -f2- | sed "s/^['\"]//;s/['\"]$//"; }
+INFLUX_USER=$(_read_env INFLUXDB_ADMIN_USER)
+INFLUX_PASS=$(_read_env INFLUXDB_ADMIN_PASSWORD)
+GRAFANA_USER=$(_read_env GF_SECURITY_ADMIN_USER)
+GRAFANA_PASS=$(_read_env GF_SECURITY_ADMIN_PASSWORD)
+GRAFANA_CREDS="${GRAFANA_USER:-admin}:${GRAFANA_PASS}"
+_gcurl() { curl -sf -K <(printf 'user = "%s"\n' "$GRAFANA_CREDS") "$@"; }
+
+PASS=0
+FAIL=0
+WARN=0
+
+pass() {
+    echo "  ✅ $1"
+    ((PASS++))
+}
+fail() {
+    echo "  ❌ $1"
+    ((FAIL++))
+}
+warn() {
+    echo "  ⚠️  $1"
+    ((WARN++))
+}
+
+influx_query() {
+    local query="$1" database="${2:-}"
+    curl -sfG \
+        -u "${INFLUX_USER:-admin}:${INFLUX_PASS}" \
+        --data-urlencode "q=$query" \
+        ${database:+--data-urlencode "db=$database"} \
+        "$INFLUXDB_URL/query"
+}
+
+echo "╔══════════════════════════════════════════════════════════╗"
+echo "║     Sim Stack — Verify Backup Integrity                  ║"
+echo "║     $(date -Iseconds)                       ║"
+echo "╚══════════════════════════════════════════════════════════╝"
+echo ""
+
+# ── 1. Check databases exist ─────────────────────────────
+echo "── 1. Databases ──"
+DATABASES=$(influx_query "SHOW DATABASES" | jq -r '.results[]?.series[]?.values[]?[0] // empty')
+
+for db in speedtest telegraf; do
+    if echo "$DATABASES" | grep -qx "$db"; then
+        pass "Database '$db' exists"
+    else
+        fail "Database '$db' missing"
+    fi
+done
+echo ""
+
+# ── 2. Speedtest data count ──────────────────────────────
+echo "── 2. Speedtest data count ──"
+COUNT_JSON=$(influx_query "SELECT COUNT(download_bandwidth) FROM speedtest" speedtest)
+COUNT=$(echo "$COUNT_JSON" | jq -r '.results[]?.series[]?.values[]?[1] // empty' | tail -1)
+
+if [[ -n "$COUNT" && "$COUNT" =~ ^[0-9]+$ ]]; then
+    echo "  📊 download_bandwidth count: $COUNT"
+    if [[ "$COUNT" -gt 100000 ]]; then
+        pass "Count looks healthy (>100k points)"
+    elif [[ "$COUNT" -gt 50000 ]]; then
+        warn "Count is lower than expected ($COUNT, expected ~122k)"
+    else
+        fail "Count is too low ($COUNT, expected ~122k)"
+    fi
+else
+    fail "Could not query download_bandwidth count"
+fi
+echo ""
+
+# ── 3. First measurement date ────────────────────────────
+echo "── 3. Date range ──"
+FIRST_JSON=$(influx_query "SELECT download_bandwidth FROM speedtest ORDER BY time ASC LIMIT 1" speedtest)
+FIRST_TIME=$(echo "$FIRST_JSON" | jq -r '.results[]?.series[]?.values[]?[0] // empty' | head -1)
+
+if [[ -n "$FIRST_TIME" ]]; then
+    echo "  📅 First measurement: $FIRST_TIME"
+    # Check if it's in 2022
+    if [[ "$FIRST_TIME" == 2022* ]]; then
+        pass "First measurement is in 2022"
+    else
+        warn "First measurement year unexpected: $FIRST_TIME"
+    fi
+else
+    fail "Could not query first measurement date"
+fi
+
+LAST_JSON=$(influx_query "SELECT download_bandwidth FROM speedtest ORDER BY time DESC LIMIT 1" speedtest)
+LAST_TIME=$(echo "$LAST_JSON" | jq -r '.results[]?.series[]?.values[]?[0] // empty' | head -1)
+
+if [[ -n "$LAST_TIME" ]]; then
+    echo "  📅 Last measurement:  $LAST_TIME"
+    # Check if it's in 2026
+    if [[ "$LAST_TIME" == 2026* ]]; then
+        pass "Last measurement is in 2026"
+    else
+        warn "Last measurement year unexpected: $LAST_TIME"
+    fi
+else
+    fail "Could not query last measurement date"
+fi
+echo ""
+
+# ── 4. Telegraf data ─────────────────────────────────────
+echo "── 4. Telegraf data ──"
+TELEGRAF_MEASUREMENTS=$(influx_query "SHOW MEASUREMENTS" telegraf | jq -r '.results[]?.series[]?.values[]?[0] // empty')
+TELEGRAF_COUNT=$(echo "$TELEGRAF_MEASUREMENTS" | wc -l)
+
+if [[ "$TELEGRAF_COUNT" -gt 0 && -n "$TELEGRAF_MEASUREMENTS" ]]; then
+    pass "Telegraf has $TELEGRAF_COUNT measurement(s)"
+    echo "     Measurements: $(echo "$TELEGRAF_MEASUREMENTS" | head -5 | tr '\n' ', ')..."
+else
+    warn "Telegraf database has no measurements (may be normal if backup had none)"
+fi
+echo ""
+
+# ── 5. Grafana datasources ──────────────────────────────
+echo "── 5. Grafana datasources ──"
+DS_JSON=$(_gcurl "$GRAFANA_URL/api/datasources" 2>/dev/null || echo "[]")
+DS_COUNT=$(echo "$DS_JSON" | jq length 2>/dev/null || echo 0)
+
+if [[ "$DS_COUNT" -ge 2 ]]; then
+    pass "Grafana has $DS_COUNT datasource(s)"
+else
+    warn "Grafana datasources: expected ≥2, got $DS_COUNT"
+fi
+
+for ds_uid in $(echo "$DS_JSON" | jq -r '.[].uid' 2>/dev/null); do
+    ds_name=$(echo "$DS_JSON" | jq -r --arg uid "$ds_uid" '.[] | select(.uid == $uid) | .name')
+    if _gcurl -X POST "$GRAFANA_URL/api/datasources/uid/$ds_uid/health" 2>/dev/null | jq -e '.status == "OK"' >/dev/null 2>&1; then
+        pass "Datasource '$ds_name' → InfluxDB connectivity OK"
+    else
+        fail "Datasource '$ds_name' cannot reach InfluxDB"
+    fi
+done
+echo ""
+
+# ── 6. Grafana dashboards ───────────────────────────────
+echo "── 6. Grafana dashboards ──"
+DASHBOARDS=$(_gcurl "$GRAFANA_URL/api/search?type=dash-db" 2>/dev/null || echo "[]")
+DASH_COUNT=$(echo "$DASHBOARDS" | jq length 2>/dev/null || echo 0)
+
+if [[ "$DASH_COUNT" -gt 0 ]]; then
+    pass "Grafana has $DASH_COUNT dashboard(s)"
+    echo "$DASHBOARDS" | jq -r '.[].title' 2>/dev/null | while read -r title; do
+        echo "     → $title"
+    done
+else
+    warn "No dashboards found in Grafana"
+fi
+echo ""
+
+# ── Summary ──────────────────────────────────────────────
+echo "╔══════════════════════════════════════════════════════════╗"
+printf "║  Results: ✅ %-3d passed  ❌ %-3d failed  ⚠️  %-3d warnings ║\n" "$PASS" "$FAIL" "$WARN"
+echo "╚══════════════════════════════════════════════════════════╝"
+echo ""
+
+if [[ "$FAIL" -eq 0 ]]; then
+    echo "🟢 VERDICT: Backup is EXPLOITABLE — data restored successfully."
+    exit 0
+else
+    echo "🔴 VERDICT: Backup has ISSUES — $FAIL check(s) failed."
+    exit 1
+fi


### PR DESCRIPTION
## Summary

3-level backup verification pipeline for RPi backups: offline integrity check, restore into sim stack, and post-restore data verification.

## Changes

### Scripts
- **`scripts/backup-check.sh`** — Offline integrity check (no stack needed): gzip -t on shards, JSON validation on dashboards, manifest/meta presence, size sanity
- **`scripts/sim-restore-backup.sh`** — Restore RPi backup into sim stack: drop DBs → influxd restore -portable → re-grant permissions → import dashboards with datasource null fix for speedtest panels
- **`scripts/sim-verify-backup.sh`** — Post-restore data verification (10 checks): DB existence, data count, date range, Grafana datasources/dashboards

### Justfile recipes
| Recipe | Description |
|--------|-------------|
| `backup-check <dir>` | Run offline integrity check |
| `sim-restore-backup <dir>` | Restore backup into running sim stack |
| `sim-verify-backup` | Verify restored data |
| `sim-test-backup <dir>` | Full pipeline: check → nuke → start → restore → verify |

### Documentation
- New `docs/backup-restore-tooling.md` with full guide
- Updated `README.md` with recipes reference and backup section

## Known issues addressed
- **Datasource null fix**: RPi dashboards have `datasource: null` on speedtest panels, which defaults to the telegraf DB in Grafana. The restore script patches these to use the correct `influxdb-speedtest` datasource UID.

## Testing
All 5 RPi backups in `backups-rpi/` validated:
- Offline integrity: all INTACT
- Full restore+verify: 122,970 speedtest points, date range 2022-11-25 → 2026-04-16, 21 telegraf measurements
