### PR TITLE
fix: auto-detect free port in pre-push E2E hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,9 @@ Installer avec `just install-hooks`. Deux hooks sont fournis :
 | Hook         | Déclencheur  | Action                                                                                          |
 | ------------ | ------------ | ----------------------------------------------------------------------------------------------- |
 | `pre-commit` | `git commit` | Lint & format check sur les fichiers stagés (sh, py, yaml, html, css, js, json, md, Dockerfile) |
-| `pre-push`   | `git push`   | E2E tests Playwright (démarre un serveur preview si nécessaire)                                 |
+| `pre-push`   | `git push`   | E2E tests Playwright (démarre un serveur preview sur un port libre auto-détecté)                |
+
+Le hook `pre-push` détecte automatiquement un port disponible pour éviter les conflits avec d'autres services (ex: port 8080 déjà occupé). Il démarre toujours son propre serveur preview isolé.
 
 ## Configuration
 

--- a/docs/2026-04-21-iperf3-vs-speedtest-analysis.md
+++ b/docs/2026-04-21-iperf3-vs-speedtest-analysis.md
@@ -1,0 +1,113 @@
+# Étude comparative : Ookla Speedtest CLI vs iperf3
+
+**Date** : 2026-04-21
+**Contexte** : Évaluation de iperf3 (avec serveurs publics gratuits via [iperf.fr](https://iperf.fr/iperf-servers.php)) comme alternative ou complément à Ookla Speedtest CLI utilisé dans le projet.
+**Décision** : Conserver Speedtest CLI comme outil principal.
+
+---
+
+## 1. Setup actuel du projet
+
+Le projet utilise **Ookla Speedtest CLI** (binaire officiel, pas le vieux `speedtest-cli` Python) :
+
+- Container Docker dédié (`Dockerfile`) basé sur `debian:bookworm-slim`
+- Exécuté **toutes les 10 min** via systemd timer (`systemd/speedtest.timer`)
+- Le script `docker-entrypoint.sh` lance `speedtest -f json`, extrait `ping_latency`, `download_bandwidth`, `upload_bandwidth` via `jq`, et écrit dans InfluxDB
+- Dashboard Grafana dédié (`speedtest/dashboard.json`)
+
+---
+
+## 2. Comparaison fonctionnelle
+
+| Critère                   | **Ookla Speedtest CLI** (actuel)                             | **iperf3 + serveurs publics**                                                            |
+| ------------------------- | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| **Ce qui est mesuré**     | Download, Upload, Ping latency, Jitter, Packet loss          | Throughput TCP/UDP brut (unidirectionnel ou bidirectionnel), Jitter, Packet loss (UDP)   |
+| **Protocoles**            | HTTP/HTTPS (simule usage web réel)                           | TCP, UDP, SCTP pur                                                                       |
+| **Sélection serveur**     | Automatique (serveur Ookla le plus proche) ou `--server-id`  | Manuel : choix explicite du serveur + port                                               |
+| **Infra serveur**         | ~16 000 serveurs Ookla mondiaux, haute dispo                 | ~30-50 serveurs publics communautaires (cf. iperf.fr)                                    |
+| **Disponibilité serveur** | Multi-connexions simultanées OK                              | **1 seule connexion à la fois** par processus serveur. Erreur `server is busy` fréquente |
+| **Output JSON**           | Oui, natif (`-f json`) — riche (ISP, serveur, URL résultat…) | Oui (`--json`) — brut (bandwidth, intervals, streams)                                    |
+| **Direction du test**     | Download + Upload en un seul run                             | Un sens à la fois par défaut. `-R` pour reverse (download). `--bidir` pour les deux      |
+| **Durée test**            | ~20-40s (auto-adaptatif)                                     | Configurable (`-t`, défaut 10s)                                                          |
+| **Installation**          | Dépôt Ookla officiel (apt)                                   | `apt install iperf3` (dans les repos Debian standard)                                    |
+| **Licence**               | Propriétaire (--accept-license --accept-gdpr)                | BSD open-source                                                                          |
+| **Dépendances**           | curl, jq, gnupg pour le repo                                 | Aucune (binaire standalone)                                                              |
+| **Image Docker**          | Image custom ~120 Mo                                         | Pourrait être ~30 Mo (iperf3 seul)                                                       |
+
+---
+
+## 3. Comparaison technique pour le monitoring
+
+| Aspect                           | **Speedtest CLI**                                                                            | **iperf3**                                                                                               |
+| -------------------------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| **Représentativité "vraie vie"** | **Excellente** — simule un usage web réel (HTTP multi-thread, sélection serveur intelligent) | **Moyenne** — mesure la capacité réseau brute, pas l'expérience utilisateur                              |
+| **Reproductibilité**             | Bonne (même serveur auto-sélectionné)                                                        | **Supérieure** — contrôle total du serveur, port, protocole, nombre de streams, taille fenêtre           |
+| **Fiabilité en cron**            | **Très fiable** — les serveurs Ookla sont toujours disponibles                               | **Risqué** — les serveurs publics sont souvent `busy`, `OOS` (Out of Service), ou supprimés sans préavis |
+| **Neutralité réseau**            | Les ISP peuvent prioriser le trafic vers les serveurs Ookla (connu et documenté)             | **Meilleur** pour détecter le throttling ISP — trafic non identifiable comme "speedtest"                 |
+| **Granularité**                  | Résultat global agrégé                                                                       | Résultats par intervalle (chaque seconde), par stream, configurable                                      |
+| **Tests UDP**                    | Non                                                                                          | Oui (`-u` avec `-b` pour le bitrate cible)                                                               |
+| **Contrôle congestion**          | Non configurable                                                                             | Configurable (`--congestion BBR`, `Cubic`…)                                                              |
+| **Consommation bande passante**  | ~200-500 Mo par test (download+upload)                                                       | Configurable : de quelques Ko à saturation                                                               |
+
+---
+
+## 4. Problèmes concrets de iperf3 pour ce projet
+
+### a) Fiabilité des serveurs publics — point critique
+
+- Serveurs communautaires = pas de SLA, pannes fréquentes
+- `iperf3: error - the server is busy running a test. try again later` très courant
+- Sur la page iperf.fr, plusieurs serveurs sont déjà marqués `OOS 03/2025`
+- Il faudrait implémenter un **fallback multi-serveurs** avec retry, ce qui complexifie le script
+
+### b) Pas de mesure download+upload en un seul run
+
+- Il faudrait 2 commandes : `iperf3 -c server -t 10` (upload) + `iperf3 -c server -t 10 -R` (download)
+- Ou `--bidir` mais ce n'est pas supporté par tous les serveurs
+
+### c) Pas de ping/latency natif
+
+- iperf3 ne mesure pas la latency au sens speedtest. Il faudrait compléter avec `ping` séparé
+- Le setup actuel collecte déjà la latency via Telegraf (`inputs.net`), mais la latency Speedtest est liée au serveur de test
+
+### d) Intégration InfluxDB
+
+- Le JSON iperf3 a une structure très différente — il faudrait réécrire `docker-entrypoint.sh` et adapter le dashboard Grafana
+
+---
+
+## 5. Où iperf3 serait pertinent (si besoin futur)
+
+| Cas d'usage                         | Intérêt                                                                               |
+| ----------------------------------- | ------------------------------------------------------------------------------------- |
+| **Détecter du traffic shaping ISP** | iperf3 vers un serveur non-Ookla peut révéler un throttling que Speedtest ne voit pas |
+| **Diagnostiquer le réseau local**   | iperf3 entre 2 machines LAN = test du switch/Wi-Fi, sans dépendance Internet          |
+| **Tests UDP / VoIP / streaming**    | Seul iperf3 peut tester UDP avec jitter et packet loss                                |
+| **Benchmark réseau avancé**         | Contrôle du nombre de streams parallèles, taille de buffer, congestion control        |
+
+---
+
+## 6. Serveurs publics iperf3 notables (Europe/France)
+
+| Serveur                    | Localisation                     | Vitesse    | Ports     | Statut (03/2025) |
+| -------------------------- | -------------------------------- | ---------- | --------- | ---------------- |
+| `ping.online.net`          | France, Île-de-France (Scaleway) | 100 Gbit/s | 5200-5209 | OK               |
+| `iperf3.moji.fr`           | France, Île-de-France (Moji)     | 100 Gbit/s | 5200-5240 | OK               |
+| `speedtest.milkywan.fr`    | France, Île-de-France (MilkyWan) | 40 Gbit/s  | 9200-9240 | OK               |
+| `paris.bbr.iperf.bytel.fr` | France, Paris (Bouygues)         | —          | —         | OK               |
+| `speedtest.serverius.net`  | Netherlands (Serverius)          | 10 Gbit/s  | 5002      | OK               |
+
+Source : <https://iperf.fr/iperf-servers.php>
+
+---
+
+## 7. Conclusion
+
+**Speedtest CLI reste le meilleur choix** pour le monitoring continu sur RPi :
+
+- **Fiabilité** : infrastructure Ookla robuste vs serveurs communautaires fragiles
+- **Simplicité** : un seul run = download + upload + ping, JSON riche
+- **Pertinence** : mesure l'expérience utilisateur réelle, pas le throughput brut
+- **Intégration** : déjà en place, testé, avec dashboard Grafana
+
+iperf3 est un outil complémentaire puissant pour du diagnostic ponctuel ou de la détection de throttling ISP, mais inadapté comme remplacement pour du monitoring automatisé fiable.

--- a/scripts/git-pre-push.sh
+++ b/scripts/git-pre-push.sh
@@ -1,30 +1,33 @@
 #!/usr/bin/env bash
 # Git pre-push hook: run E2E tests before pushing.
-# Requires a preview server on localhost:8080.
+# Automatically finds a free port for the preview server.
 set -euo pipefail
 
-echo "▶ Checking if preview server is running on :8080 ..."
-if ! curl -sf -o /dev/null http://127.0.0.1:8080 2>/dev/null; then
-    echo "⚠  No preview server on :8080 — starting one in background ..."
-    just preview-dev 8080 &
-    PREVIEW_PID=$!
-    # Wait for server to be ready (max 30s)
-    for i in $(seq 1 30); do
-        if curl -sf -o /dev/null http://127.0.0.1:8080 2>/dev/null; then
-            break
-        fi
-        if [[ "$i" -eq 30 ]]; then
-            echo "❌ Preview server failed to start"
-            kill "$PREVIEW_PID" 2>/dev/null || true
-            exit 1
-        fi
-        sleep 1
-    done
-    trap 'kill $PREVIEW_PID 2>/dev/null || true' EXIT
-fi
+# ── Find a free port ──────────────────────────────────────
+find_free_port() {
+    python3 -c 'import socket; s=socket.socket(); s.bind(("",0)); print(s.getsockname()[1]); s.close()'
+}
 
-echo "▶ Running E2E tests ..."
-just e2e || {
+PORT=$(find_free_port)
+echo "▶ Starting preview server on :${PORT} ..."
+just preview-dev "$PORT" &
+PREVIEW_PID=$!
+trap 'kill $PREVIEW_PID 2>/dev/null || true; wait $PREVIEW_PID 2>/dev/null || true' EXIT
+
+# Wait for server to be ready (max 30s)
+for i in $(seq 1 30); do
+    if curl -sf -o /dev/null "http://127.0.0.1:${PORT}" 2>/dev/null; then
+        break
+    fi
+    if [[ "$i" -eq 30 ]]; then
+        echo "❌ Preview server failed to start on :${PORT}"
+        exit 1
+    fi
+    sleep 1
+done
+
+echo "▶ Running E2E tests against :${PORT} ..."
+just e2e "http://127.0.0.1:${PORT}" || {
     echo ""
     echo "❌ E2E tests failed. Push aborted."
     exit 1


### PR DESCRIPTION
## Problème

Le hook `pre-push` utilisait le port **8080 en dur** pour lancer le serveur preview E2E. Si un autre service occupait déjà ce port (fréquent en développement), les tests E2E échouaient avec un timeout `waitForAppReady` et **le push était bloqué**.

## Solution

Le hook détecte automatiquement un port libre via `python3 socket.bind(("",0))` et démarre **toujours** son propre serveur preview sur ce port aléatoire.

### Avant
```
❌ Port 8080 occupé par un autre service → page de login au lieu de la preview
→ E2E timeout → push bloqué
```

### Après
```
▶ Starting preview server on :38847 ...
▶ Running E2E tests against :38847 ...
12 passed (9.5s)
✅ Pre-push checks passed
```

## Changements

- `scripts/git-pre-push.sh` :
  - Ajout de `find_free_port()` utilisant Python socket pour trouver un port disponible
  - Le hook démarre **toujours** son propre serveur preview (plus de réutilisation d'un serveur existant sur :8080)
  - Le port dynamique est passé à `just preview-dev` et `just e2e`
  - Cleanup propre du serveur via trap SIGTERM

## Impact

- **Aucun changement** sur les recettes `just preview-dev` / `just e2e` (le défaut 8080 reste pour l'usage interactif)
- **Aucun changement** sur `playwright.config.js` ou les tests
- Seul le hook automatique est affecté

## Tests

- ✅ `shellcheck scripts/git-pre-push.sh` — 0 erreurs
- ✅ `bash scripts/git-pre-push.sh` — 12/12 tests E2E passent
- ✅ `git push` avec port 8080 occupé — push réussi sur port aléatoire
