### PR TITLE
feat: sync status indicator dot in navbar

### DIFF
--- a/gh-pages/app.js
+++ b/gh-pages/app.js
@@ -1,3 +1,28 @@
+// ── Sync status indicator ─────────────────────────────────────
+{
+  const dot = document.getElementById('syncDot');
+  const timeEl = document.querySelector('nav .meta time[datetime]');
+  if (dot && timeEl) {
+    const iso = timeEl.getAttribute('datetime');
+    const updated = new Date(iso);
+    if (!isNaN(updated)) {
+      // Allow simulating staleness via ?simAge=<minutes> (dev only)
+      const simAge = new URLSearchParams(window.location.search).get('simAge');
+      const ageMin = simAge !== null ? Number(simAge) : (Date.now() - updated.getTime()) / 60000;
+      if (ageMin < 10) {
+        dot.className = 'sync-dot sync-ok';
+        dot.title = 'Synchronisation OK (< 10 min)';
+      } else if (ageMin < 20) {
+        dot.className = 'sync-dot sync-warn';
+        dot.title = 'Synchronisation dégradée (10–20 min)';
+      } else {
+        dot.className = 'sync-dot sync-err';
+        dot.title = 'Synchronisation en échec (> 20 min)';
+      }
+    }
+  }
+}
+
 // ── Data loading ─────────────────────────────────────────────
 const _dataReady = Promise.all([
   fetch('data.json').then((r) => r.json()),

--- a/gh-pages/index.template.html
+++ b/gh-pages/index.template.html
@@ -19,7 +19,10 @@
     <nav>
       <div class="inner">
         <div class="brand">speed<span class="hi">monitor</span></div>
-        <div class="meta">Mise &agrave; jour : <time>__LAST_UPDATE__</time></div>
+        <div class="meta">
+          <span class="sync-dot" id="syncDot" title=""></span>Mise &agrave; jour :
+          <time datetime="__LAST_UPDATE_ISO__">__LAST_UPDATE__</time>
+        </div>
       </div>
     </nav>
 

--- a/gh-pages/style.css
+++ b/gh-pages/style.css
@@ -139,6 +139,28 @@ nav .meta {
 nav .meta time {
   color: var(--blue);
 }
+.sync-dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-right: 8px;
+  vertical-align: middle;
+  background: var(--text3);
+  transition: background 0.3s;
+}
+.sync-dot.sync-ok {
+  background: var(--green);
+  box-shadow: 0 0 6px var(--green);
+}
+.sync-dot.sync-warn {
+  background: var(--orange);
+  box-shadow: 0 0 6px var(--orange);
+}
+.sync-dot.sync-err {
+  background: var(--red);
+  box-shadow: 0 0 6px var(--red);
+}
 
 /* ── HERO ── */
 .hero {

--- a/scripts/render-template.py
+++ b/scripts/render-template.py
@@ -45,11 +45,13 @@ def main():
     dt = datetime.now(tz=TZ)
     tz_abbr = dt.strftime("%Z")  # CET or CEST
     now = dt.strftime(f"%d/%m/%Y %H:%M ({tz_abbr})")
+    now_iso = dt.isoformat()
     gen = dt.strftime(f"%d/%m/%Y à %H:%M:%S ({tz_abbr})")
     if suffix:
         gen = f"{gen} {suffix}"
 
     html = html.replace("__LAST_UPDATE__", now)
+    html = html.replace("__LAST_UPDATE_ISO__", now_iso)
     html = html.replace("__GENERATED_AT__", gen)
 
     with open(output_path, "w") as f:

--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -105,6 +105,7 @@ test.describe('read-only checks', () => {
       '__SPEEDTEST_DATA__',
       '__ALERTS_DATA__',
       '__LAST_UPDATE__',
+      '__LAST_UPDATE_ISO__',
       '__GENERATED_AT__',
     ]) {
       expect(html).not.toContain(token);


### PR DESCRIPTION
## Sync status indicator

Ajoute une pastille colorée à côté du timestamp "Mise à jour" dans la navbar qui indique visuellement la santé de la synchronisation des données avec le RPi.

### Comportement

| Couleur | Condition | Signification |
|---------|-----------|---------------|
| 🟢 Vert | Données < 10 min | Synchronisation OK |
| 🟠 Orange | Données 10–20 min | Synchro possiblement ratée (1 cycle) |
| 🔴 Rouge | Données > 20 min | Synchro en échec (2+ cycles ratés) |

### Motivation

Le timestamp seul oblige à calculer mentalement l'écart avec l'heure actuelle. La pastille donne un feedback visuel immédiat sur l'état du pipeline de données RPi → GitHub Pages.

### Changements

- **`scripts/render-template.py`** — Nouveau placeholder `__LAST_UPDATE_ISO__` (ISO 8601) pour parsing JS fiable
- **`gh-pages/index.template.html`** — Ajout du `<span class="sync-dot">` + attribut `datetime` sur `<time>`
- **`gh-pages/app.js`** — Logique de calcul de l'âge des données + attribution de la classe CSS. Supporte `?simAge=<minutes>` pour simulation en dev
- **`gh-pages/style.css`** — Styles `.sync-ok` / `.sync-warn` / `.sync-err` avec glow effect
- **`tests/e2e.spec.js`** — Ajout de `__LAST_UPDATE_ISO__` dans le check des placeholders

### Test

```
just preview-dev
# Vert  : http://localhost:8080/
# Orange: http://localhost:8080/?simAge=15
# Rouge : http://localhost:8080/?simAge=25
```

### Commits (SoC)

1. `feat:` — Logique backend + frontend (render-template, app.js, HTML)
2. `style:` — CSS de la pastille
3. `test:` — Mise à jour e2e