### PR TITLE
feat: quality score indicator dots on stat cards

### DIFF
--- a/docs/quality-score-indicators.md
+++ b/docs/quality-score-indicators.md
@@ -1,0 +1,194 @@
+# Quality Score Indicators — Pastilles de qualité connexion
+
+## Objectif
+
+Fournir un indicateur visuel **at-a-glance** de la qualité de la connexion internet pour chaque métrique (Download, Upload, Ping) sur le dashboard GitHub Pages.
+
+Chaque stat card affiche une **pastille à gradient de couleur continu** (vert → jaune → orange → rouge) calculée à partir d'un score composite qui combine deux dimensions :
+
+1. **Performance** — la valeur absolue de la métrique est-elle bonne ?
+2. **Stabilité** — les mesures sont-elles régulières dans le temps ?
+
+## Deux dimensions orthogonales
+
+### Performance (valeur absolue)
+
+Évalue si la médiane des mesures sur la plage temporelle sélectionnée atteint les seuils attendus pour une connexion fibre 1 Gbps.
+
+**Score performance** $p \in [0, 1]$ (0 = nominal, 1 = critique) :
+
+Pour Download et Upload (plus = mieux) :
+
+$$p = \text{clamp}\left(\frac{\text{seuil\_bon} - \text{médiane}}{\text{seuil\_bon} - \text{seuil\_mauvais}},\ 0,\ 1\right)$$
+
+Pour Ping (moins = mieux, échelle inversée) :
+
+$$p = \text{clamp}\left(\frac{\text{médiane} - \text{seuil\_bon}}{\text{seuil\_mauvais} - \text{seuil\_bon}},\ 0,\ 1\right)$$
+
+### Stabilité (dispersion)
+
+Évalue la régularité des mesures via le **coefficient de variation (CV)**.
+
+**Score stabilité** $s \in [0, 1]$ (0 = parfaitement stable, 1 = très instable) :
+
+$$s = \text{clamp}\left(\frac{CV - CV_{\text{bon}}}{CV_{\text{mauvais}} - CV_{\text{bon}}},\ 0,\ 1\right)$$
+
+## Score composite
+
+Les deux dimensions sont combinées avec une pondération qui privilégie la stabilité :
+
+$$\text{score} = 0.3 \times p + 0.7 \times s$$
+
+Le score final (0 = critique, 1 = parfait) est affiché en pourcentage : $\text{qualité} = 1 - \text{score}$.
+
+### Justification de la pondération 30/70
+
+La stabilité est pondérée plus fortement que la performance brute car :
+
+- Une connexion rapide mais erratique est moins fiable qu'une connexion modérée mais constante
+- Les variations de débit impactent davantage l'expérience utilisateur (streaming, visio) que le débit crête
+- La performance pure est déjà visible via la valeur médiane affichée ; la pastille apporte une information complémentaire sur la _fiabilité_
+
+## Seuils configurés
+
+### Performance
+
+| Métrique | Seuil vert (bon) | Seuil rouge (mauvais) | Direction     |
+| -------- | ---------------- | --------------------- | ------------- |
+| Download | ≥ 800 Mb/s       | ≤ 500 Mb/s            | Plus = mieux  |
+| Upload   | ≥ 500 Mb/s       | ≤ 200 Mb/s            | Plus = mieux  |
+| Ping     | ≤ 20 ms          | ≥ 50 ms               | Moins = mieux |
+
+Ces seuils sont calibrés pour une **connexion fibre 1 Gbps** (Free/Orange). Ils devraient être ajustés si le type de connexion change.
+
+### Stabilité (CV)
+
+| Seuil            | CV           | Signification           |
+| ---------------- | ------------ | ----------------------- |
+| Vert (parfait)   | ≤ 0.05 (5%)  | Variation négligeable   |
+| Rouge (instable) | ≥ 0.25 (25%) | Variation significative |
+
+Ces seuils sont **universels** et indépendants de la métrique : un CV de 5% signifie la même chose que la valeur soit en Mb/s ou en ms.
+
+## Mapping couleur (gradient HSL)
+
+Le score composite est converti en teinte (hue) sur l'espace colorimétrique HSL :
+
+$$\text{hue} = 120 \times (1 - \text{score})$$
+
+$$\text{couleur} = \text{hsl}(\text{hue},\ 85\%,\ 50\%)$$
+
+| Score | Hue  | Couleur résultante |
+| ----- | ---- | ------------------ |
+| 0.00  | 120° | Vert vif           |
+| 0.25  | 90°  | Vert-jaune         |
+| 0.50  | 60°  | Jaune              |
+| 0.75  | 30°  | Orange             |
+| 1.00  | 0°   | Rouge              |
+
+L'avantage du gradient continu vs 3 paliers discrets : les nuances intermédiaires donnent un signal plus fin sans avoir à lire les chiffres.
+
+## Outils statistiques utilisés
+
+### Médiane
+
+Valeur centrale d'un jeu de données trié. Plus robuste que la moyenne face aux outliers.
+
+- Pour $n$ impair : $\text{med} = x_{\lfloor n/2 \rfloor}$
+- Pour $n$ pair : $\text{med} = \frac{x_{n/2 - 1} + x_{n/2}}{2}$
+
+Référence : [Wikipedia — Median](https://en.wikipedia.org/wiki/Median)
+
+### Écart-type (σ) et variance
+
+Mesure de dispersion des valeurs autour de la moyenne. On utilise la variance **corrigée** (diviseur $n - 1$, estimateur de Bessel) pour un échantillon :
+
+$$\sigma = \sqrt{\frac{1}{n-1} \sum_{i=1}^{n} (x_i - \bar{x})^2}$$
+
+Référence : [Wikipedia — Standard deviation](https://en.wikipedia.org/wiki/Standard_deviation#Corrected_sample_standard_deviation)
+
+### Coefficient de variation (CV)
+
+Rapport de l'écart-type sur la moyenne, exprimé en ratio (ou en %) :
+
+$$CV = \frac{\sigma}{\bar{x}}$$
+
+**Pourquoi le CV et pas l'écart-type seul ?**
+
+Le CV est adimensionnel et permet de comparer la variabilité entre des métriques d'échelles différentes :
+
+- Download σ = 5 Mb/s sur μ = 940 Mb/s → CV = 0.5% (très stable)
+- Ping σ = 2 ms sur μ = 12 ms → CV = 16.7% (moyennement stable)
+
+Sans le CV, on comparerait des pommes et des oranges.
+
+Référence : [Wikipedia — Coefficient of variation](https://en.wikipedia.org/wiki/Coefficient_of_variation)
+
+### Fonction clamp
+
+Sature une valeur dans l'intervalle $[0, 1]$ :
+
+$$\text{clamp}(x, 0, 1) = \max(0, \min(1, x))$$
+
+Utilisée pour normaliser les scores intermédiaires avant la combinaison pondérée.
+
+### Espace colorimétrique HSL
+
+Hue-Saturation-Lightness — permet de faire varier uniquement la teinte (hue) pour créer un gradient perceptuellement linéaire du vert au rouge.
+
+- Hue 120° = vert
+- Hue 60° = jaune
+- Hue 0° = rouge
+
+Référence : [MDN — HSL](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl)
+
+## Tooltip détaillé
+
+Au clic sur la pastille, un tooltip affiche le détail du calcul :
+
+```
+Excellent (100%)
+Performance      100%
+  médiane 941.8 Mb/s (vert ≥ 800, rouge ≤ 500)
+Stabilité        100%
+  CV = 0.006 (σ = 5.6 Mb/s, vert ≤ 5%, rouge ≥ 25%)
+Pondération      30/70
+  perf × 0.3 + stab × 0.7
+```
+
+### Labels de qualité
+
+| Score  | Label     |
+| ------ | --------- |
+| ≥ 70%  | Excellent |
+| 40–70% | Correct   |
+| 20–40% | Dégradé   |
+| < 20%  | Critique  |
+
+## Pastille de synchronisation (navbar)
+
+En complément des pastilles de qualité, une pastille dans la navbar indique la fraîcheur des données :
+
+| Couleur | Condition        | Signification                             |
+| ------- | ---------------- | ----------------------------------------- |
+| Vert    | Données < 10 min | Pipeline de synchro RPi → GitHub Pages OK |
+| Orange  | 10–20 min        | Synchro possiblement ratée (1 cycle)      |
+| Rouge   | > 20 min         | Synchro en échec (2+ cycles ratés)        |
+
+Le calcul compare le timestamp ISO 8601 injecté par `render-template.py` (`__LAST_UPDATE_ISO__`) avec `Date.now()` côté navigateur.
+
+## Implémentation
+
+- **`gh-pages/app.js`** — Fonctions `qualityScore()` et `qualityTooltipHtml()`, seuils dans `QUALITY_THRESHOLDS`
+- **`gh-pages/style.css`** — Classes `.q-dot`, `.q-tip`, `.q-tip-grid`
+- **`scripts/render-template.py`** — Placeholder `__LAST_UPDATE_ISO__` pour la pastille sync
+
+### Paramètre de simulation
+
+Le paramètre URL `?simAge=<minutes>` permet de simuler un âge de données pour tester la pastille de synchronisation sans attendre un vrai délai.
+
+## Évolutions possibles
+
+- Rendre les seuils configurables via un fichier JSON ou des variables d'environnement
+- Ajouter un historique du score de qualité (trend sur 7j/30j)
+- Alerter (via le système d'alertes existant) si le score passe sous un seuil configurable

--- a/docs/quality-score-indicators.md
+++ b/docs/quality-score-indicators.md
@@ -27,11 +27,26 @@ $$p = \text{clamp}\left(\frac{\text{médiane} - \text{seuil\_bon}}{\text{seuil\_
 
 ### Stabilité (dispersion)
 
-Évalue la régularité des mesures via le **coefficient de variation (CV)**.
+Évalue la régularité des mesures via l'**écart interquartile normalisé (IQR/médiane)**.
+
+L'IQR (Interquartile Range = Q3 − Q1) mesure la largeur des 50% centraux des données. Normalisé par la médiane, il devient un ratio adimensionnel comparable entre métriques d'échelles différentes.
 
 **Score stabilité** $s \in [0, 1]$ (0 = parfaitement stable, 1 = très instable) :
 
-$$s = \text{clamp}\left(\frac{CV - CV_{\text{bon}}}{CV_{\text{mauvais}} - CV_{\text{bon}}},\ 0,\ 1\right)$$
+$$s = \text{clamp}\left(\frac{\text{IQR}/\text{médiane} - R_{\text{bon}}}{R_{\text{mauvais}} - R_{\text{bon}}},\ 0,\ 1\right)$$
+
+#### Pourquoi l'IQR et pas le coefficient de variation (CV) ?
+
+Le CV ($\sigma / \bar{x}$) est **extrêmement sensible aux outliers** car l'écart-type dépend du carré des écarts. En pratique, un seul point aberrant (ex : un speedtest à 38 Mb/s sur 4275 mesures à ~940 Mb/s) peut faire exploser σ et donc le CV, donnant un faux diagnostic d'instabilité.
+
+Exemple réel sur 30 jours de Download :
+
+| Métrique            | CV (σ/μ)                                | IQR/médiane                  |
+| ------------------- | --------------------------------------- | ---------------------------- |
+| Download (4275 pts) | **34.3%** ❌ (σ=276 à cause d'outliers) | **2.7%** ✅ (Q1=920, Q3=945) |
+| Upload (4275 pts)   | ~15%                                    | **~25%** (Q1≈550, Q3≈720)    |
+
+L'IQR est un estimateur **robuste** de la dispersion : il ignore les 25% les plus bas et les 25% les plus hauts, ne gardant que la masse centrale. C'est le concept d'[intervalle de confiance](https://fr.wikipedia.org/wiki/Intervalle_de_confiance) appliqué aux quartiles.
 
 ## Score composite
 
@@ -61,14 +76,14 @@ La stabilité est pondérée plus fortement que la performance brute car :
 
 Ces seuils sont calibrés pour une **connexion fibre 1 Gbps** (Free/Orange). Ils devraient être ajustés si le type de connexion change.
 
-### Stabilité (CV)
+### Stabilité (IQR normalisé)
 
-| Seuil            | CV           | Signification           |
-| ---------------- | ------------ | ----------------------- |
-| Vert (parfait)   | ≤ 0.05 (5%)  | Variation négligeable   |
-| Rouge (instable) | ≥ 0.25 (25%) | Variation significative |
+| Seuil            | IQR/médiane  | Signification                                |
+| ---------------- | ------------ | -------------------------------------------- |
+| Vert (parfait)   | ≤ 0.05 (5%)  | 50% centraux concentrés (très régulier)      |
+| Rouge (instable) | ≥ 0.30 (30%) | 50% centraux dispersés (connexion erratique) |
 
-Ces seuils sont **universels** et indépendants de la métrique : un CV de 5% signifie la même chose que la valeur soit en Mb/s ou en ms.
+Ces seuils sont **universels** et indépendants de la métrique. Un IQR/médiane de 5% signifie que les 50% centraux des mesures tiennent dans ±2.5% de la médiane.
 
 ## Mapping couleur (gradient HSL)
 
@@ -99,28 +114,49 @@ Valeur centrale d'un jeu de données trié. Plus robuste que la moyenne face aux
 
 Référence : [Wikipedia — Median](https://en.wikipedia.org/wiki/Median)
 
-### Écart-type (σ) et variance
+### Quartiles et écart interquartile (IQR)
 
-Mesure de dispersion des valeurs autour de la moyenne. On utilise la variance **corrigée** (diviseur $n - 1$, estimateur de Bessel) pour un échantillon :
+Les **quartiles** divisent un jeu de données trié en 4 parts égales :
 
-$$\sigma = \sqrt{\frac{1}{n-1} \sum_{i=1}^{n} (x_i - \bar{x})^2}$$
+- **Q1** (25e percentile) : 25% des données sont inférieures
+- **Q2** (médiane) : 50%
+- **Q3** (75e percentile) : 75% des données sont inférieures
 
-Référence : [Wikipedia — Standard deviation](https://en.wikipedia.org/wiki/Standard_deviation#Corrected_sample_standard_deviation)
+L'**écart interquartile (IQR)** mesure la dispersion des 50% centraux :
 
-### Coefficient de variation (CV)
+$$IQR = Q3 - Q1$$
 
-Rapport de l'écart-type sur la moyenne, exprimé en ratio (ou en %) :
+C'est un estimateur **robuste** : contrairement à l'écart-type, il est insensible aux outliers car il ignore les 25% extrêmes de chaque côté.
+
+Référence : [Wikipedia — Interquartile range](https://en.wikipedia.org/wiki/%C3%89cart_interquartile)
+
+### IQR normalisé (Quartile Coefficient of Dispersion)
+
+Pour comparer la dispersion entre métriques d'échelles différentes (Mb/s vs ms), on normalise l'IQR par la médiane :
+
+$$\text{IQR normalisé} = \frac{Q3 - Q1}{\text{médiane}}$$
+
+C'est l'analogue robuste du coefficient de variation (CV = σ/μ), parfois appelé **Quartile Coefficient of Dispersion** dans la littérature.
+
+Référence : [Wikipedia — Quartile coefficient of dispersion](https://en.wikipedia.org/wiki/Quartile_coefficient_of_dispersion)
+
+### Intervalle de confiance et robustesse
+
+L'IQR correspond à l'**intervalle de confiance à 50%** de la distribution empirique : il contient la moitié des observations centrales. Cette approche est directement liée au concept d'[intervalle de confiance](https://fr.wikipedia.org/wiki/Intervalle_de_confiance).
+
+En statistique robuste, on privilégie les estimateurs basés sur les quantiles (médiane, IQR) plutôt que sur les moments (moyenne, écart-type) dès que la distribution peut contenir des outliers — ce qui est systématiquement le cas des mesures réseau (coupures, congestion temporaire, erreurs de mesure).
+
+Référence : [Wikipedia — Robust statistics](https://en.wikipedia.org/wiki/Robust_statistics)
+
+### Pourquoi pas le CV (σ/μ) ? — Leçon apprise
+
+Le coefficient de variation a été utilisé dans la v1 mais s'est avéré inadapté :
 
 $$CV = \frac{\sigma}{\bar{x}}$$
 
-**Pourquoi le CV et pas l'écart-type seul ?**
+L'écart-type $\sigma$ dépend du **carré** des écarts à la moyenne. Un seul outlier (ex : 38 Mb/s sur 4275 mesures à ~940 Mb/s) contribue $(940-38)^2 = 813\,604$ à la variance, gonflant σ de 5.6 à 276 Mb/s et le CV de 0.6% à 34%. Le diagnostic passait de "Excellent" à "Dégradé" à cause d'un seul point.
 
-Le CV est adimensionnel et permet de comparer la variabilité entre des métriques d'échelles différentes :
-
-- Download σ = 5 Mb/s sur μ = 940 Mb/s → CV = 0.5% (très stable)
-- Ping σ = 2 ms sur μ = 12 ms → CV = 16.7% (moyennement stable)
-
-Sans le CV, on comparerait des pommes et des oranges.
+L'IQR, ne regardant que Q1-Q3, est totalement insensible à ce type d'aberration.
 
 Référence : [Wikipedia — Coefficient of variation](https://en.wikipedia.org/wiki/Coefficient_of_variation)
 
@@ -151,7 +187,8 @@ Excellent (100%)
 Performance      100%
   médiane 941.8 Mb/s (vert ≥ 800, rouge ≤ 500)
 Stabilité        100%
-  CV = 0.006 (σ = 5.6 Mb/s, vert ≤ 5%, rouge ≥ 25%)
+  IQR/méd = 2.7% (Q1=920.3, Q3=945.1, IQR=24.8 Mb/s)
+  vert ≤ 5%, rouge ≥ 30%
 Pondération      30/70
   perf × 0.3 + stab × 0.7
 ```

--- a/docs/quality-score-indicators.md
+++ b/docs/quality-score-indicators.md
@@ -91,15 +91,27 @@ Le score composite est converti en teinte (hue) sur l'espace colorimétrique HSL
 
 $$\text{hue} = 120 \times (1 - \text{score})$$
 
-$$\text{couleur} = \text{hsl}(\text{hue},\ 85\%,\ 50\%)$$
+### Compensation de luminosité (zone jaune)
 
-| Score | Hue  | Couleur résultante |
-| ----- | ---- | ------------------ |
-| 0.00  | 120° | Vert vif           |
-| 0.25  | 90°  | Vert-jaune         |
-| 0.50  | 60°  | Jaune              |
-| 0.75  | 30°  | Orange             |
-| 1.00  | 0°   | Rouge              |
+Sur fond sombre, les teintes jaune-orange (hue 40–80°) apparaissent naturellement plus éteintes que le vert ou le rouge à lightness constante. Pour compenser, la lightness est modulée par une sinusoïde qui booste la zone jaune :
+
+$$L = 50 + 10 \times \sin\!\left(\frac{\text{hue}}{120} \times \pi\right)$$
+
+| Hue  | Lightness | Effet                         |
+| ---- | --------- | ----------------------------- |
+| 0°   | 50%       | Rouge — pas de boost          |
+| 60°  | 60%       | Jaune — boost maximal (+10pp) |
+| 120° | 50%       | Vert — pas de boost           |
+
+$$\text{couleur} = \text{hsl}(\text{hue},\ 85\%,\ L\%)$$
+
+| Score | Hue  | L   | Couleur résultante |
+| ----- | ---- | --- | ------------------ |
+| 0.00  | 120° | 50% | Vert vif           |
+| 0.25  | 90°  | 57% | Vert-jaune         |
+| 0.50  | 60°  | 60% | Jaune (boosté)     |
+| 0.75  | 30°  | 57% | Orange             |
+| 1.00  | 0°   | 50% | Rouge              |
 
 L'avantage du gradient continu vs 3 paliers discrets : les nuances intermédiaires donnent un signal plus fin sans avoir à lire les chiffres.
 
@@ -219,6 +231,15 @@ Le calcul compare le timestamp ISO 8601 injecté par `render-template.py` (`__LA
 - **`gh-pages/app.js`** — Fonctions `qualityScore()` et `qualityTooltipHtml()`, seuils dans `QUALITY_THRESHOLDS`
 - **`gh-pages/style.css`** — Classes `.q-dot`, `.q-tip`, `.q-tip-grid`
 - **`scripts/render-template.py`** — Placeholder `__LAST_UPDATE_ISO__` pour la pastille sync
+
+### Détails visuels de la pastille
+
+| Propriété         | Valeur                               |
+| ----------------- | ------------------------------------ |
+| Taille            | 12 × 12 px                           |
+| Bordure           | 1.5px solid rgba(255,255,255,0.15)   |
+| Glow (box-shadow) | 0 0 8px 2px (couleur de la pastille) |
+| Transition        | background 0.3s, box-shadow 0.3s     |
 
 ### Paramètre de simulation
 

--- a/gh-pages/app.js
+++ b/gh-pages/app.js
@@ -344,6 +344,32 @@ _dataReady.then(async ([RAW_DATA]) => {
     }
   });
 
+  // ── Quality dot tooltip (click to show/hide) ───────────────
+  let _qualityData = {};
+  const qTip = document.createElement('div');
+  qTip.className = 'q-tip';
+  document.body.appendChild(qTip);
+  let qTipActive = null;
+
+  document.addEventListener('click', (e) => {
+    const dot = e.target.closest?.('.q-dot');
+    if (dot && dot !== qTipActive) {
+      qTipActive = dot;
+      const metric = dot.dataset.metric;
+      const d = _qualityData[metric];
+      if (d) {
+        qTip.innerHTML = qualityTooltipHtml(metric, d.q, d.median, d.n, d.unit);
+        qTip.style.display = 'block';
+        const r = dot.getBoundingClientRect();
+        qTip.style.left = `${r.left + r.width / 2}px`;
+        qTip.style.top = `${r.bottom + 8}px`;
+      }
+    } else if (!dot || dot === qTipActive) {
+      qTipActive = null;
+      qTip.style.display = 'none';
+    }
+  });
+
   // ── Constants ──────────────────────────────────────────────
   const HOUR = 3_600_000;
   const BAND_THRESHOLD = 48; // hours: above this → band mode
@@ -668,9 +694,83 @@ _dataReady.then(async ([RAW_DATA]) => {
   ];
 
   // ── Stat card builder ──────────────────────────────────────
-  const statCard = (cls, label, mainVal, chartSVG, summary, lastVal, nPts, timeRange) =>
+  // ── Quality score (composite: performance + stability) ────
+  // Performance thresholds: { good, bad } — below bad → score=1, above good → score=0
+  // For ping: inverted (lower is better)
+  const QUALITY_THRESHOLDS = {
+    dl: { good: 800, bad: 500 },
+    ul: { good: 500, bad: 200 },
+    pi: { good: 20, bad: 50 }, // inverted: low=good
+  };
+  const PERF_WEIGHT = 0.3,
+    STAB_WEIGHT = 0.7;
+
+  const qualityScore = (metric, median, sorted, avg, nPts) => {
+    const th = QUALITY_THRESHOLDS[metric];
+    // Performance score (0=nominal, 1=critical)
+    let perf;
+    if (metric === 'pi') {
+      perf = median <= th.good ? 0 : median >= th.bad ? 1 : (median - th.good) / (th.bad - th.good);
+    } else {
+      perf = median >= th.good ? 0 : median <= th.bad ? 1 : (th.good - median) / (th.good - th.bad);
+    }
+    // Stability via coefficient of variation (CV = stddev / mean)
+    // CV thresholds: ≤ 0.05 = perfectly stable, ≥ 0.25 = very unstable
+    let variance = 0;
+    for (let i = 0; i < nPts; i++) {
+      const d = sorted[i] - avg;
+      variance += d * d;
+    }
+    const stddev = nPts > 1 ? Math.sqrt(variance / (nPts - 1)) : 0;
+    const cv = avg > 0 ? stddev / avg : 0;
+    const CV_GOOD = 0.05,
+      CV_BAD = 0.25;
+    const stab = cv <= CV_GOOD ? 0 : cv >= CV_BAD ? 1 : (cv - CV_GOOD) / (CV_BAD - CV_GOOD);
+    // Composite
+    const score = Math.min(1, Math.max(0, PERF_WEIGHT * perf + STAB_WEIGHT * stab));
+    const hue = 120 * (1 - score);
+    const color = `hsl(${hue.toFixed(0)}, 85%, 50%)`;
+    return { score, perf, stab, cv, stddev, color, hue };
+  };
+
+  const fmtPct = (v) => (v * 100).toFixed(0) + '%';
+
+  const qualityTooltipHtml = (metric, q, median, nPts, unit) => {
+    const th = QUALITY_THRESHOLDS[metric];
+    const thDir = metric === 'pi' ? '\u2264' : '\u2265';
+    const thBad = metric === 'pi' ? '\u2265' : '\u2264';
+    const label =
+      q.score < 0.3
+        ? 'Excellent'
+        : q.score < 0.6
+          ? 'Correct'
+          : q.score < 0.8
+            ? 'D\u00e9grad\u00e9'
+            : 'Critique';
+    return `<div class="q-tip-title">${label} <span style="color:${q.color}">(${fmtPct(1 - q.score)})</span></div>
+<div class="q-tip-grid">
+  <span class="q-tip-label">Performance</span><span class="q-tip-val">${fmtPct(1 - q.perf)}</span>
+  <span class="q-tip-detail">m\u00e9diane ${median.toFixed(1)} ${unit} (vert ${thDir} ${th.good}, rouge ${thBad} ${th.bad})</span>
+  <span class="q-tip-label">Stabilit\u00e9</span><span class="q-tip-val">${fmtPct(1 - q.stab)}</span>
+  <span class="q-tip-detail">CV = ${q.cv.toFixed(3)} (\u03c3 = ${q.stddev.toFixed(1)} ${unit}, vert \u2264 5%, rouge \u2265 25%)</span>
+  <span class="q-tip-label">Pond\u00e9ration</span><span class="q-tip-val">${(PERF_WEIGHT * 100).toFixed(0)}/${(STAB_WEIGHT * 100).toFixed(0)}</span>
+  <span class="q-tip-detail">perf \u00d7 ${PERF_WEIGHT} + stab \u00d7 ${STAB_WEIGHT}</span>
+</div>`;
+  };
+
+  const statCard = (
+    cls,
+    label,
+    mainVal,
+    chartSVG,
+    summary,
+    lastVal,
+    nPts,
+    timeRange,
+    qualityInfo,
+  ) =>
     `<div class="stat ${cls}">
-      <div class="v">${mainVal}</div>
+      <div class="v">${mainVal}${qualityInfo ? `<span class="q-dot" data-metric="${cls}" style="background:${qualityInfo.color};box-shadow:0 0 6px ${qualityInfo.color}"></span>` : ''}</div>
       <div class="l">${label} <span class="l-sub">m\u00e9diane</span></div>
       <div class="dcl-wrap">${chartSVG}</div>
       <div class="stat-sum">${summary}</div>
@@ -762,6 +862,17 @@ _dataReady.then(async ([RAW_DATA]) => {
       const ulHist = computeHistogram(ulSorted, ulMn, ulMx);
       const piHist = computeHistogram(piSorted, piMn, piMx);
 
+      const dlQ = qualityScore('dl', dlMed, dlSorted, dlAvg, n);
+      const ulQ = qualityScore('ul', ulMed, ulSorted, ulAvg, n);
+      const piQ = qualityScore('pi', piMed, piSorted, piAvg, n);
+
+      // Store quality data for tooltip on click
+      _qualityData = {
+        dl: { q: dlQ, median: dlMed, n, unit: 'Mb/s' },
+        ul: { q: ulQ, median: ulMed, n, unit: 'Mb/s' },
+        pi: { q: piQ, median: piMed, n, unit: 'ms' },
+      };
+
       statsEl.innerHTML =
         statCard(
           'dl',
@@ -772,6 +883,7 @@ _dataReady.then(async ([RAW_DATA]) => {
           fmtSpd0(dl[i1 - 1]),
           n,
           trLabel,
+          dlQ,
         ) +
         statCard(
           'ul',
@@ -782,6 +894,7 @@ _dataReady.then(async ([RAW_DATA]) => {
           fmtSpd0(ul[i1 - 1]),
           n,
           trLabel,
+          ulQ,
         ) +
         statCard(
           'pi',
@@ -792,6 +905,7 @@ _dataReady.then(async ([RAW_DATA]) => {
           pi[i1 - 1].toFixed(1),
           n,
           trLabel,
+          piQ,
         );
 
       // ── Legend ─────────────────────────────────────────────

--- a/gh-pages/app.js
+++ b/gh-pages/app.js
@@ -733,7 +733,9 @@ _dataReady.then(async ([RAW_DATA]) => {
     // Composite
     const score = Math.min(1, Math.max(0, PERF_WEIGHT * perf + STAB_WEIGHT * stab));
     const hue = 120 * (1 - score);
-    const color = `hsl(${hue.toFixed(0)}, 85%, 50%)`;
+    // Boost lightness in the yellow zone (hue 40-80°) which appears dim on dark backgrounds
+    const lightness = 50 + 10 * Math.sin((hue / 120) * Math.PI);
+    const color = `hsl(${hue.toFixed(0)}, 85%, ${lightness.toFixed(0)}%)`;
     return { score, perf, stab, q1, q3, iqr, iqrRatio, color, hue };
   };
 
@@ -775,7 +777,7 @@ _dataReady.then(async ([RAW_DATA]) => {
     qualityInfo,
   ) =>
     `<div class="stat ${cls}">
-      <div class="v">${mainVal}${qualityInfo ? `<span class="q-dot" data-metric="${cls}" style="background:${qualityInfo.color};box-shadow:0 0 6px ${qualityInfo.color}"></span>` : ''}</div>
+      <div class="v">${mainVal}${qualityInfo ? `<span class="q-dot" data-metric="${cls}" style="background:${qualityInfo.color};box-shadow:0 0 8px 2px ${qualityInfo.color}"></span>` : ''}</div>
       <div class="l">${label} <span class="l-sub">m\u00e9diane</span></div>
       <div class="dcl-wrap">${chartSVG}</div>
       <div class="stat-sum">${summary}</div>

--- a/gh-pages/app.js
+++ b/gh-pages/app.js
@@ -714,23 +714,27 @@ _dataReady.then(async ([RAW_DATA]) => {
     } else {
       perf = median >= th.good ? 0 : median <= th.bad ? 1 : (th.good - median) / (th.good - th.bad);
     }
-    // Stability via coefficient of variation (CV = stddev / mean)
-    // CV thresholds: ≤ 0.05 = perfectly stable, ≥ 0.25 = very unstable
-    let variance = 0;
-    for (let i = 0; i < nPts; i++) {
-      const d = sorted[i] - avg;
-      variance += d * d;
-    }
-    const stddev = nPts > 1 ? Math.sqrt(variance / (nPts - 1)) : 0;
-    const cv = avg > 0 ? stddev / avg : 0;
-    const CV_GOOD = 0.05,
-      CV_BAD = 0.25;
-    const stab = cv <= CV_GOOD ? 0 : cv >= CV_BAD ? 1 : (cv - CV_GOOD) / (CV_BAD - CV_GOOD);
+    // Stability via IQR / median (robust to outliers)
+    // IQR = Q3 - Q1 = interquartile range (middle 50% of data)
+    // Normalized by median to be scale-independent
+    // Thresholds: ≤ 0.05 = very stable, ≥ 0.30 = very unstable
+    const q1 = pctOf(sorted, 25);
+    const q3 = pctOf(sorted, 75);
+    const iqr = q3 - q1;
+    const iqrRatio = median > 0 ? iqr / median : 0;
+    const IQR_GOOD = 0.05,
+      IQR_BAD = 0.3;
+    const stab =
+      iqrRatio <= IQR_GOOD
+        ? 0
+        : iqrRatio >= IQR_BAD
+          ? 1
+          : (iqrRatio - IQR_GOOD) / (IQR_BAD - IQR_GOOD);
     // Composite
     const score = Math.min(1, Math.max(0, PERF_WEIGHT * perf + STAB_WEIGHT * stab));
     const hue = 120 * (1 - score);
     const color = `hsl(${hue.toFixed(0)}, 85%, 50%)`;
-    return { score, perf, stab, cv, stddev, color, hue };
+    return { score, perf, stab, q1, q3, iqr, iqrRatio, color, hue };
   };
 
   const fmtPct = (v) => (v * 100).toFixed(0) + '%';
@@ -752,7 +756,8 @@ _dataReady.then(async ([RAW_DATA]) => {
   <span class="q-tip-label">Performance</span><span class="q-tip-val">${fmtPct(1 - q.perf)}</span>
   <span class="q-tip-detail">m\u00e9diane ${median.toFixed(1)} ${unit} (vert ${thDir} ${th.good}, rouge ${thBad} ${th.bad})</span>
   <span class="q-tip-label">Stabilit\u00e9</span><span class="q-tip-val">${fmtPct(1 - q.stab)}</span>
-  <span class="q-tip-detail">CV = ${q.cv.toFixed(3)} (\u03c3 = ${q.stddev.toFixed(1)} ${unit}, vert \u2264 5%, rouge \u2265 25%)</span>
+  <span class="q-tip-detail">IQR/m\u00e9d = ${(q.iqrRatio * 100).toFixed(1)}% (Q1=${q.q1.toFixed(1)}, Q3=${q.q3.toFixed(1)}, IQR=${q.iqr.toFixed(1)} ${unit})</span>
+  <span class="q-tip-detail">vert \u2264 5%, rouge \u2265 30%</span>
   <span class="q-tip-label">Pond\u00e9ration</span><span class="q-tip-val">${(PERF_WEIGHT * 100).toFixed(0)}/${(STAB_WEIGHT * 100).toFixed(0)}</span>
   <span class="q-tip-detail">perf \u00d7 ${PERF_WEIGHT} + stab \u00d7 ${STAB_WEIGHT}</span>
 </div>`;

--- a/gh-pages/style.css
+++ b/gh-pages/style.css
@@ -260,12 +260,13 @@ nav .meta time {
 /* quality dot */
 .q-dot {
   display: inline-block;
-  width: 10px;
-  height: 10px;
+  width: 12px;
+  height: 12px;
   border-radius: 50%;
   margin-left: 8px;
   vertical-align: middle;
   cursor: pointer;
+  border: 1.5px solid rgba(255, 255, 255, 0.15);
   transition:
     background 0.3s,
     box-shadow 0.3s;

--- a/gh-pages/style.css
+++ b/gh-pages/style.css
@@ -257,6 +257,61 @@ nav .meta time {
   font-weight: 600;
 }
 
+/* quality dot */
+.q-dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-left: 8px;
+  vertical-align: middle;
+  cursor: pointer;
+  transition:
+    background 0.3s,
+    box-shadow 0.3s;
+}
+
+/* quality tooltip */
+.q-tip {
+  display: none;
+  position: fixed;
+  transform: translateX(-50%);
+  background: var(--surface2);
+  color: var(--text);
+  font-size: 0.72rem;
+  font-family: 'Geist Mono', 'Geist Mono Fallback', monospace;
+  padding: 10px 14px;
+  border-radius: 6px;
+  border: 1px solid var(--border2);
+  white-space: nowrap;
+  z-index: 110;
+  line-height: 1.5;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+}
+.q-tip-title {
+  font-size: 0.82rem;
+  font-weight: 700;
+  margin-bottom: 6px;
+}
+.q-tip-grid {
+  display: grid;
+  grid-template-columns: auto auto;
+  gap: 2px 12px;
+}
+.q-tip-label {
+  color: var(--text3);
+}
+.q-tip-val {
+  text-align: right;
+  font-weight: 600;
+}
+.q-tip-detail {
+  grid-column: 1 / -1;
+  color: var(--text3);
+  font-size: 0.62rem;
+  margin-bottom: 4px;
+}
+
 /* decile tooltip */
 .dcl-tip {
   display: none;


### PR DESCRIPTION
## Quality score indicator dots

Ajoute une pastille à **gradient de couleur continu** (HSL) sur chaque stat card (Download, Upload, Ping) qui indique la qualité de la connexion via un score composite.

### Score composite

Deux dimensions combinées :
- **Performance (30%)** — médiane vs seuils nominaux fibre 1G
- **Stabilité (70%)** — coefficient de variation (CV = σ/μ)

$$\text{score} = 0.3 \times \text{perf} + 0.7 \times \text{stabilité}$$

### Pourquoi le CV ?

Le CV est adimensionnel et compare la variabilité indépendamment de l'échelle :
- Download σ=5.6 sur μ=941 → CV=0.6% → **très stable** ✅
- Upload σ=88 sur μ=638 → CV=13.8% → **instable** ⚠️

L'approche précédente (ratio bin dominant / total) donnait des faux négatifs : un Download ultra-stable réparti sur 2 bins adjacents était pénalisé à tort.

### Seuils

| Métrique | Vert | Rouge |
|----------|------|-------|
| Download | ≥ 800 Mb/s | ≤ 500 Mb/s |
| Upload | ≥ 500 Mb/s | ≤ 200 Mb/s |
| Ping | ≤ 20 ms | ≥ 50 ms |
| CV (stabilité) | ≤ 5% | ≥ 25% |

### Tooltip au clic

Détail complet : performance %, stabilité %, CV, σ, seuils, pondération.

### Commits (SoC)

1. `feat:` — Logique JS (qualityScore, tooltip, thresholds)
2. `style:` — CSS quality dot + tooltip
3. `docs:` — Documentation complète (formules, références stats, seuils)