### PR TITLE
fix: add color-scheme dark to prevent forced dark mode color distortion

### DIFF
--- a/gh-pages/index.template.html
+++ b/gh-pages/index.template.html
@@ -4,6 +4,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark" />
     <link rel="icon" href="data:," />
     <meta
       name="description"

--- a/gh-pages/style.css
+++ b/gh-pages/style.css
@@ -63,6 +63,7 @@
   box-sizing: border-box;
 }
 :root {
+  color-scheme: dark;
   --bg: #0c0c0d;
   --bg2: #141415;
   --surface: #1a1a1c;


### PR DESCRIPTION
## Problème

Les pastilles de qualité (quality dots) apparaissent **sans glow visible** sur les navigateurs ayant le mode sombre forcé activé, notamment **Brave** avec le flag `WebContentsForceDark`.

### Cause racine

Brave (et Chrome avec `--enable-features=WebContentsForceDark`) applique une transformation automatique des couleurs CSS pour "assombrir" les pages web. Cette transformation re-mappe les valeurs `hsl()` utilisées dans `box-shadow` et `background`, ce qui :

- Réduit la luminosité des teintes jaune-orange (hue 40-80°)
- Atténue voire supprime le glow (`box-shadow`) des pastilles
- Affecte également le vert (hue 120°) dans certains cas

Le problème est que cette transformation est appliquée **même si la page est déjà en thème sombre** (`--bg: #0c0c0d`).

### Diagnostic

1. Page de test avec 12 techniques de glow différentes → **aucune** ne fonctionnait sous Brave
2. Inspection de `brave://gpu` → flag `WebContentsForceDark` détecté dans la command line
3. Ajout de `color-scheme: dark` → **toutes les techniques fonctionnent**

### Solution

Déclarer explicitement que la page utilise un thème sombre via :

- `<meta name="color-scheme" content="dark">` dans le HTML
- `color-scheme: dark` dans `:root` du CSS

Cela indique au navigateur que la page gère déjà son propre thème sombre, et le navigateur **skip** la transformation `WebContentsForceDark`.

### Impact

- **Brave** : corrige le glow invisible sur toutes les pastilles
- **Chrome/Edge avec forced dark mode** : même correction
- **Firefox/Safari/Chrome standard** : aucun changement visible (la page était déjà sombre)
- **Effet secondaire positif** : les scrollbars et contrôles natifs du navigateur adoptent le thème sombre

### Référence

- [MDN — color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme)
- [Chrome — Auto Dark Mode](https://developer.chrome.com/blog/auto-dark-theme/)
