### PR TITLE
refactor: extraire build-gh-pages.sh — un seul pipeline de build

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
     paths:
       - 'gh-pages/**'
+      - 'scripts/build-gh-pages.sh'
       - 'scripts/render-template.py'
       - 'scripts/extract-live-data.py'
   workflow_dispatch: # Manual trigger
@@ -36,18 +37,8 @@ jobs:
           git show origin/gh-pages:alerts.json > "$BUILD_DIR/alerts.json" 2>/dev/null || \
             cp tests/fixtures/alerts.json "$BUILD_DIR/alerts.json"
 
-          python3 scripts/render-template.py \
-            gh-pages/index.template.html \
-            "$BUILD_DIR/data.json" \
-            "$BUILD_DIR/alerts.json" \
-            "$BUILD_DIR/index.html"
-
-          cp gh-pages/style.css "$BUILD_DIR/"
-          cp -r gh-pages/fonts "$BUILD_DIR/"
           npm install -g terser
-          for f in app.js lib.js state.js sync-status.js alerts.js charts.js time-controls.js time-picker.js; do
-            terser "gh-pages/$f" --compress --mangle --module -o "$BUILD_DIR/$f"
-          done
+          bash scripts/build-gh-pages.sh "$BUILD_DIR" "$BUILD_DIR/data.json" "$BUILD_DIR/alerts.json"
 
       - name: Push to gh-pages branch
         run: |

--- a/.github/workflows/preview-pr.yml
+++ b/.github/workflows/preview-pr.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'gh-pages/**'
+      - 'scripts/build-gh-pages.sh'
       - 'scripts/extract-live-data.py'
       - 'scripts/render-template.py'
       - 'scripts/publish-gh-pages.sh'
@@ -35,26 +36,15 @@ jobs:
           echo "  data.json:   $(wc -c < "$BUILD_DIR/data.json") bytes"
           echo "  alerts.json: $(wc -c < "$BUILD_DIR/alerts.json") bytes"
 
-          echo "── Building page from PR template + prod data ──"
-          python3 scripts/render-template.py \
-            gh-pages/index.template.html \
-            "$BUILD_DIR/data.json" \
-            "$BUILD_DIR/alerts.json" \
-            "$BUILD_DIR/index.html" \
-            "(PR preview)"
-
           echo "── Verifying extract-live-data.py round-trip ──"
+          bash scripts/build-gh-pages.sh "$BUILD_DIR" "$BUILD_DIR/data.json" "$BUILD_DIR/alerts.json" "(PR preview)"
           python3 scripts/extract-live-data.py "$BUILD_DIR/index.html" "$BUILD_DIR"
 
           mkdir -p _surge_deploy
-          cp "$BUILD_DIR/index.html" _surge_deploy/
-          cp "$BUILD_DIR/data.json" "$BUILD_DIR/alerts.json" _surge_deploy/
-          cp gh-pages/style.css _surge_deploy/
-          for f in app.js lib.js state.js sync-status.js alerts.js \
-                   charts.js time-controls.js time-picker.js; do
-            cp "gh-pages/$f" _surge_deploy/
-          done
-          cp -r gh-pages/fonts _surge_deploy/
+          cp "$BUILD_DIR"/index.html "$BUILD_DIR"/style.css _surge_deploy/
+          cp "$BUILD_DIR"/data.json "$BUILD_DIR"/alerts.json _surge_deploy/
+          cp "$BUILD_DIR"/*.js _surge_deploy/
+          cp -r "$BUILD_DIR"/fonts _surge_deploy/
 
       - name: Deploy to Surge
         id: surge

--- a/scripts/build-gh-pages.sh
+++ b/scripts/build-gh-pages.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Build a complete static monitoring site from template + data.
+#
+# Usage: build-gh-pages.sh <build_dir> <data_json> <alerts_json> [suffix]
+#
+# Arguments:
+#   build_dir    Directory to write the built site into (must exist)
+#   data_json    Path to data.json
+#   alerts_json  Path to alerts.json
+#   suffix       Optional suffix for render-template.py (e.g. "(PR preview)")
+#
+# The script renders index.html, copies static assets (CSS, fonts),
+# and minifies JS modules with terser when available.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEMPLATE="$SCRIPT_DIR/gh-pages/index.template.html"
+
+BUILD_DIR="${1:?Usage: build-gh-pages.sh <build_dir> <data_json> <alerts_json> [suffix]}"
+DATA_JSON="${2:?Missing data_json argument}"
+ALERTS_JSON="${3:?Missing alerts_json argument}"
+SUFFIX="${4:-}"
+
+echo "── Building page from template ──"
+
+# Render HTML
+python3 "$SCRIPT_DIR/scripts/render-template.py" \
+    "$TEMPLATE" "$DATA_JSON" "$ALERTS_JSON" "$BUILD_DIR/index.html" "$SUFFIX"
+
+# Copy static assets
+cp "$SCRIPT_DIR/gh-pages/style.css" "$BUILD_DIR/"
+cp -r "$SCRIPT_DIR/gh-pages/fonts" "$BUILD_DIR/"
+
+# JS modules — minify with terser when available, plain copy otherwise
+JS_MODULES=(app.js lib.js state.js sync-status.js alerts.js charts.js time-controls.js time-picker.js)
+if command -v terser &>/dev/null; then
+    for f in "${JS_MODULES[@]}"; do
+        terser "$SCRIPT_DIR/gh-pages/$f" --compress --mangle --module -o "$BUILD_DIR/$f"
+    done
+else
+    for f in "${JS_MODULES[@]}"; do
+        cp "$SCRIPT_DIR/gh-pages/$f" "$BUILD_DIR/"
+    done
+fi

--- a/scripts/preview-dev.sh
+++ b/scripts/preview-dev.sh
@@ -5,7 +5,6 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-TEMPLATE="$SCRIPT_DIR/gh-pages/index.template.html"
 PORT="${1:-8080}"
 
 BUILD_DIR=$(mktemp -d)
@@ -28,22 +27,7 @@ else
 fi
 
 # ── 2. Build page from template ──────────────────────────
-echo ""
-echo "── Building page from template ──"
-
-python3 "$SCRIPT_DIR/scripts/render-template.py" "$TEMPLATE" "$BUILD_DIR/data.json" "$BUILD_DIR/alerts.json" "$BUILD_DIR/index.html"
-
-# Copy static assets
-cp "$SCRIPT_DIR/gh-pages/style.css" "$BUILD_DIR/"
-cp -r "$SCRIPT_DIR/gh-pages/fonts" "$BUILD_DIR/"
-JS_MODULES=(app.js lib.js state.js sync-status.js alerts.js charts.js time-controls.js time-picker.js)
-if command -v terser &>/dev/null; then
-    for f in "${JS_MODULES[@]}"; do
-        terser "$SCRIPT_DIR/gh-pages/$f" --compress --mangle --module -o "$BUILD_DIR/$f"
-    done
-else
-    for f in "${JS_MODULES[@]}"; do cp "$SCRIPT_DIR/gh-pages/$f" "$BUILD_DIR/"; done
-fi
+bash "$SCRIPT_DIR/scripts/build-gh-pages.sh" "$BUILD_DIR" "$BUILD_DIR/data.json" "$BUILD_DIR/alerts.json"
 
 # ── 3. Serve ─────────────────────────────────────────────
 echo ""

--- a/scripts/publish-gh-pages.sh
+++ b/scripts/publish-gh-pages.sh
@@ -12,7 +12,6 @@ source "$SCRIPT_DIR/scripts/lib-common.sh"
 
 detect_container_cli
 load_env "$SCRIPT_DIR/.env"
-TEMPLATE="$SCRIPT_DIR/gh-pages/index.template.html"
 
 # Parse args
 PREVIEW=false
@@ -109,30 +108,14 @@ ALERT_COUNT=$(echo "$ALERTS_DATA" | python3 -c "import json,sys; d=json.load(sys
 echo "  → $ALERT_COUNT alert rules exported"
 
 # ── 2. Build the static page ─────────────────────────────
-echo ""
-echo "── Building static page ──"
-
 BUILD_DIR=$(mktemp -d)
 trap 'rm -rf "$BUILD_DIR"' EXIT
 
-# Write data to temp files, then inject into template
 echo "$JSON_DATA" >"$BUILD_DIR/data.json"
 echo "$ALERTS_DATA" >"$BUILD_DIR/alerts.json"
 
-python3 "$SCRIPT_DIR/scripts/render-template.py" "$TEMPLATE" "$BUILD_DIR/data.json" "$BUILD_DIR/alerts.json" "$BUILD_DIR/index.html"
-
-# Copy static assets
-cp "$SCRIPT_DIR/gh-pages/style.css" "$BUILD_DIR/"
-cp -r "$SCRIPT_DIR/gh-pages/fonts" "$BUILD_DIR/"
-JS_MODULES=(app.js lib.js state.js sync-status.js alerts.js charts.js time-controls.js time-picker.js)
-if command -v terser &>/dev/null; then
-    echo "  → Minifying JS modules with terser"
-    for f in "${JS_MODULES[@]}"; do
-        terser "$SCRIPT_DIR/gh-pages/$f" --compress --mangle --module -o "$BUILD_DIR/$f"
-    done
-else
-    for f in "${JS_MODULES[@]}"; do cp "$SCRIPT_DIR/gh-pages/$f" "$BUILD_DIR/"; done
-fi
+echo ""
+bash "$SCRIPT_DIR/scripts/build-gh-pages.sh" "$BUILD_DIR" "$BUILD_DIR/data.json" "$BUILD_DIR/alerts.json"
 
 # ── 3. Preview or Push ────────────────────────────────────
 if [[ "$PREVIEW" == "true" ]]; then

--- a/scripts/publish-template.sh
+++ b/scripts/publish-template.sh
@@ -10,7 +10,6 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-TEMPLATE="$SCRIPT_DIR/gh-pages/index.template.html"
 LIVE_URL="https://yoyonel.github.io/rpi-internet-monitoring/"
 REPO_URL=$(git -C "$SCRIPT_DIR" remote get-url origin 2>/dev/null || echo "https://github.com/yoyonel/rpi-internet-monitoring.git")
 
@@ -46,16 +45,7 @@ fi
 
 # ── 2. Build page from local template ────────────────────
 echo ""
-echo "── Building page from local template ──"
-
-python3 "$SCRIPT_DIR/scripts/render-template.py" "$TEMPLATE" "$BUILD_DIR/data.json" "$BUILD_DIR/alerts.json" "$BUILD_DIR/index.html" "(template update)"
-
-# Copy static assets
-cp "$SCRIPT_DIR/gh-pages/style.css" "$BUILD_DIR/"
-for f in app.js lib.js state.js sync-status.js alerts.js charts.js time-controls.js time-picker.js; do
-    cp "$SCRIPT_DIR/gh-pages/$f" "$BUILD_DIR/"
-done
-cp -r "$SCRIPT_DIR/gh-pages/fonts" "$BUILD_DIR/"
+bash "$SCRIPT_DIR/scripts/build-gh-pages.sh" "$BUILD_DIR" "$BUILD_DIR/data.json" "$BUILD_DIR/alerts.json" "(template update)"
 
 # ── 3. Preview or Push ────────────────────────────────────
 if [[ "$PREVIEW" == "true" ]]; then


### PR DESCRIPTION
## Summary

Centralise la logique de build du site statique dans `scripts/build-gh-pages.sh`.

### Avant
3 scripts + 1 workflow CI dupliquaient ~15 lignes de build chacun (render-template.py, copie CSS/fonts, minification JS).

### Après
Un seul script `build-gh-pages.sh` appelé par tous :
- `scripts/preview-dev.sh`
- `scripts/publish-template.sh`
- `scripts/publish-gh-pages.sh`
- `.github/workflows/deploy-gh-pages.yml`
- `.github/workflows/preview-pr.yml`

### Bénéfices
- **Localité** : ajouter un asset = 1 ligne dans 1 fichier
- **Levier** : le build est testable indépendamment
- Élimine ~60 lignes de duplication

### Tests
- 67 unit tests ✅
- 12 E2E tests ✅
- Shell syntax validation ✅
- `docker compose config` ✅

Closes #27