### PR TITLE
feat: 30-day status bars with Today default, click-to-navigate & active day indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,18 +119,18 @@ just install-timers
 
 ### Testing
 
-| Commande                     | RPi requis | Description                                                     |
-| ---------------------------- | ---------- | --------------------------------------------------------------- |
-| `just test`                  | **oui**    | Suite de régression complète (17 checks)                        |
-| `just test-unit`             | non        | Tests unitaires `lib.js` (Node.js, 39 tests, ~300ms)            |
-| `just test-e2e`              | non        | Tests E2E Playwright (nécessite un preview actif sur :8080)     |
-| `just check`                 | **oui**    | Health check rapide des 4 services                              |
-| `just e2e [url]`             | non        | Tests E2E Playwright contre une preview (défaut: :8080)         |
-| `just sim-test`              | non        | Smoke tests de la stack sim (25 checks)                         |
-| `just lint`                  | non        | Vérifier le formatage et le linting de tous les sources         |
-| `just fmt`                   | non        | Auto-formater tous les fichiers sources                         |
-| `just lighthouse [flags]`    | non        | Audit Lighthouse sur la page prod (mobile+desktop par défaut)   |
-| `just lighthouse-report [p]` | non        | Analyse priorisée des rapports Lighthouse (mobile/desktop/both) |
+| Commande                     | RPi requis | Description                                                           |
+| ---------------------------- | ---------- | --------------------------------------------------------------------- |
+| `just test`                  | **oui**    | Suite de régression complète (17 checks)                              |
+| `just test-unit`             | non        | Tests unitaires `lib.js` (Node.js, 75 tests, ~500ms)                  |
+| `just test-e2e`              | non        | Tests E2E Playwright (12 tests, nécessite un preview actif sur :8080) |
+| `just check`                 | **oui**    | Health check rapide des 4 services                                    |
+| `just e2e [url]`             | non        | Tests E2E Playwright contre une preview (défaut: :8080)               |
+| `just sim-test`              | non        | Smoke tests de la stack sim (25 checks)                               |
+| `just lint`                  | non        | Vérifier le formatage et le linting de tous les sources               |
+| `just fmt`                   | non        | Auto-formater tous les fichiers sources                               |
+| `just lighthouse [flags]`    | non        | Audit Lighthouse sur la page prod (mobile+desktop par défaut)         |
+| `just lighthouse-report [p]` | non        | Analyse priorisée des rapports Lighthouse (mobile/desktop/both)       |
 
 ### Publication & Preview
 
@@ -235,14 +235,21 @@ Page statique déployée sur [yoyonel.github.io/rpi-internet-monitoring](https:/
 
 ### Architecture frontend
 
-| Fichier                        | Rôle                                                                                                    |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------- |
-| `gh-pages/lib.js`              | Fonctions pures : LTTB downsampling, bucketisation, histogramme, score de qualité, stats, binary search |
-| `gh-pages/app.js`              | Orchestration DOM : Chart.js, rendu cartes stats, time picker, zoom/pan, alertes                        |
-| `gh-pages/style.css`           | Dark theme responsive                                                                                   |
-| `gh-pages/index.template.html` | Template HTML avec placeholders `__LAST_UPDATE__` / `__GENERATED_AT__`                                  |
+| Fichier                        | Rôle                                                                                                   |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------ |
+| `gh-pages/lib.js`              | Fonctions pures : LTTB downsampling, bucketisation, histogramme, score de qualité, daily status, stats |
+| `gh-pages/app.js`              | Orchestration DOM : charge les données, initialise les composants, connecte les callbacks              |
+| `gh-pages/charts.js`           | Chart.js : création des graphes bandwidth/latency, rendu, zoom/pan, render hook                        |
+| `gh-pages/state.js`            | État partagé : données typées, range courant (start/end/isLive/isToday)                                |
+| `gh-pages/status-bar.js`       | Barres de statut 30 jours (style GitHub) : rendu, tooltips, clic→navigation, indicateur jour actif     |
+| `gh-pages/time-controls.js`    | Gestion du time range : presets, Today, shift, zoom, applyRange                                        |
+| `gh-pages/time-picker.js`      | Sélecteur de dates (calendrier + presets absolus)                                                      |
+| `gh-pages/alerts.js`           | Rendu des alertes RPi depuis alerts.json                                                               |
+| `gh-pages/sync-status.js`      | Indicateur de fraîcheur des données (dot vert/orange/rouge)                                            |
+| `gh-pages/style.css`           | Dark theme responsive                                                                                  |
+| `gh-pages/index.template.html` | Template HTML avec placeholders `__LAST_UPDATE__` / `__GENERATED_AT__`                                 |
 
-`app.js` importe `lib.js` via ES modules (`<script type="module">`). Les fonctions pures de `lib.js` sont testées unitairement avec `node --test` (39 tests, ~300ms, zéro dépendance).
+`app.js` orchestre les modules via ES modules (`<script type="module">`). Les fonctions pures de `lib.js` sont testées unitairement avec `node --test` (75 tests, ~500ms, zéro dépendance).
 
 ### Architecture shell (scripts/)
 

--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -33,8 +33,11 @@
 | **Histogram**     | A 10-bin SVG distribution chart inside a Stat Card showing the frequency distribution of values in the active Time Range                           | distribution, bar chart                |
 | **Decile Chart**  | An SVG bar chart inside a Stat Card showing the 10 decile (P10–P100) values for the active Time Range                                              | percentile chart                       |
 | **Time Range**    | The currently selected time window (start, end) controlling which Measurements are displayed                                                       | range, window, period, interval        |
-| **Preset**        | A predefined Time Range duration (6h, 12h, 24h, 2d, 7d, 30d) selectable via toolbar buttons                                                        | button, quick range                    |
+| **Preset**        | A predefined Time Range duration (6h, 12h, 24h, 2d, 7d, 30d) or "Today" (midnight → now) selectable via toolbar buttons                            | button, quick range                    |
+| **Today**         | A special Preset that sets the Time Range from midnight local time to the latest data point. Default view on page load                             | Auj., aujourd'hui                      |
 | **Time Picker**   | The Grafana-style dropdown panel with a calendar, absolute inputs, relative presets, and recent ranges                                             | date picker, calendar, range picker    |
+| **Status Bar**    | A GitHub-style 30-day uptime bar per metric (DL, UL, Ping). Each bar represents one day's Quality Score with a muted HSL color                     | uptime bar, daily status               |
+| **Active Day**    | The Status Bar segment(s) overlapping the current Time Range, highlighted with an outline indicator                                                | selected day, current day              |
 | **Sync Status**   | The colored dot in the nav bar indicating data freshness (OK < 10 min, degraded 10–20 min, error > 20 min)                                         | freshness indicator, staleness dot     |
 | **Alert**         | A Grafana-provisioned threshold rule (CPU, temperature, RAM, swap, disk, load) whose state (firing/pending/inactive) is displayed on the Dashboard | warning, notification, alarm           |
 
@@ -60,11 +63,13 @@
 
 ## Code architecture
 
-| Term                   | Definition                                                                                                                                             | Aliases to avoid        |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------- |
-| **lib.js**             | The pure-function ES module containing all algorithms (LTTB, Bucketize, Quality Score, stats, formatting) — zero DOM dependency, testable with Node.js | library, utils, helpers |
-| **app.js**             | The thin orchestrator that loads data, initializes components, and wires them together — the only entry point in the HTML                              | main, index, controller |
-| **State** (`state.js`) | The single mutable data store shared by all UI components, holding typed arrays and the current Time Range                                             | store, context, global  |
+| Term                   | Definition                                                                                                                                                           | Aliases to avoid        |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| **lib.js**             | The pure-function ES module containing all algorithms (LTTB, Bucketize, Quality Score, Daily Status, stats, formatting) — zero DOM dependency, testable with Node.js | library, utils, helpers |
+| **app.js**             | The thin orchestrator that loads data, initializes components, and wires callbacks (e.g., applyRange, highlightActiveDay) — the only entry point in the HTML         | main, index, controller |
+| **State** (`state.js`) | The single mutable data store shared by all UI components, holding typed arrays and the current Time Range (including isToday flag)                                  | store, context, global  |
+| **status-bar.js**      | Self-contained module rendering Status Bars, tooltips, click-to-navigate, and active day highlighting                                                                | uptime module           |
+| **charts.js**          | Chart.js wrapper: creates/updates bandwidth and latency charts, manages render cycle with onRender hook                                                              | chart module, renderer  |
 
 ## Relationships
 

--- a/gh-pages/app.js
+++ b/gh-pages/app.js
@@ -6,9 +6,10 @@ import { HOUR } from './lib.js';
 import { data, range, initData } from './state.js';
 import { initSyncStatus } from './sync-status.js';
 import { renderAlerts } from './alerts.js';
-import { initCharts, render, initialRender, applyZoomPlugin } from './charts.js';
-import { initTimeControls } from './time-controls.js';
+import { initCharts, render, initialRender, applyZoomPlugin, onRender } from './charts.js';
+import { initTimeControls, applyRange } from './time-controls.js';
 import { initTimePicker } from './time-picker.js';
+import { initStatusBars, highlightActiveDay } from './status-bar.js';
 
 // ── Sync status (no data dependency) ─────────────────────────
 initSyncStatus();
@@ -56,6 +57,11 @@ _dataReady.then(async ([RAW_DATA]) => {
   initData(ts, dl, ul, pi);
   await yieldToMain();
 
+  // ── Status bars (GitHub-style uptime) ──────────────────────
+  initStatusBars(applyRange);
+  onRender(highlightActiveDay);
+  await yieldToMain();
+
   // ── Initialize components ──────────────────────────────────
   await initCharts(yieldToMain);
   await yieldToMain();
@@ -75,6 +81,7 @@ _dataReady.then(async ([RAW_DATA]) => {
     range.end = max;
     range.currentH = (range.end - range.start) / HOUR;
     range.isLive = range.end >= range.dataEnd;
+    range.isToday = false;
     render();
   };
   const zoomOpts = {

--- a/gh-pages/charts.js
+++ b/gh-pages/charts.js
@@ -133,6 +133,13 @@ const bandTooltipPi = {
 
 /** Create Chart.js instances. Call once after data is loaded. */
 export const initCharts = async (yieldToMain) => {
+  // Wait for Chart.js global to be available (loaded via <script defer>)
+  if (typeof Chart === 'undefined') {
+    await new Promise((resolve) => {
+      const check = () => (typeof Chart !== 'undefined' ? resolve() : setTimeout(check, 50));
+      check();
+    });
+  }
   Chart.defaults.color = '#555';
   Chart.defaults.borderColor = '#2a2a2d';
 
@@ -427,9 +434,13 @@ const doRender = () => {
   document.getElementById('rangeLabel').textContent = `${fmtDateTzLocal(
     range.start,
   )}  \u2192  ${fmtDateTzLocal(range.end)}`;
-  document
-    .querySelectorAll('.rb')
-    .forEach((b) => b.classList.toggle('on', parseInt(b.dataset.hours) === range.currentH));
+  document.querySelectorAll('.rb').forEach((b) => {
+    if (b.id === 'btnToday') {
+      b.classList.toggle('on', range.isToday);
+    } else {
+      b.classList.toggle('on', !range.isToday && parseInt(b.dataset.hours) === range.currentH);
+    }
+  });
   lastMode = mode;
 };
 
@@ -439,17 +450,26 @@ const flushCharts = () => {
 };
 
 /** Schedule a render on next animation frame (debounced). */
+let renderHook = null;
+
+/** Register a callback to run after each render. */
+export const onRender = (fn) => {
+  renderHook = fn;
+};
+
 export const render = () => {
   cancelAnimationFrame(renderRAF);
   renderRAF = requestAnimationFrame(() => {
     doRender();
     flushCharts();
+    if (renderHook) renderHook();
   });
 };
 
 /** Run initial render with split updates to avoid long tasks. */
 export const initialRender = async (yieldToMain) => {
   doRender();
+  if (renderHook) renderHook();
   bwChart.update('none');
   await yieldToMain();
   piChart.update('none');

--- a/gh-pages/index.template.html
+++ b/gh-pages/index.template.html
@@ -12,15 +12,7 @@
     />
     <title>Internet Speed Monitor — RPi4</title>
     <link rel="preload" href="data.json" as="fetch" crossorigin />
-    <link rel="preload" href="https://cdn.jsdelivr.net/npm/chart.js@4" as="script" />
     <link rel="preload" href="fonts/geist-latin.woff2" as="font" type="font/woff2" crossorigin />
-    <link rel="modulepreload" href="lib.js" />
-    <link rel="modulepreload" href="state.js" />
-    <link rel="modulepreload" href="sync-status.js" />
-    <link rel="modulepreload" href="alerts.js" />
-    <link rel="modulepreload" href="charts.js" />
-    <link rel="modulepreload" href="time-controls.js" />
-    <link rel="modulepreload" href="time-picker.js" />
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
@@ -42,6 +34,11 @@
 
       <div class="stats" id="statsRow"></div>
 
+      <section class="sb-section">
+        <div class="stitle">Statut 30 jours</div>
+        <div id="statusBars"></div>
+      </section>
+
       <section class="alerts" id="alertsSec">
         <div class="stitle">Alertes RPi</div>
         <div id="alertsList"></div>
@@ -50,10 +47,11 @@
       <div class="tp">
         <button class="nb" id="btnBack" title="Reculer">&laquo;</button>
         <div class="rg">
+          <button class="rb rb-today on" id="btnToday" data-hours="today">Auj.</button>
           <button class="rb" data-hours="6">6h</button>
           <button class="rb" data-hours="12">12h</button>
           <button class="rb" data-hours="24">24h</button>
-          <button class="rb on" data-hours="48">2j</button>
+          <button class="rb" data-hours="48">2j</button>
           <button class="rb" data-hours="168">7j</button>
           <button class="rb" data-hours="720">30j</button>
         </div>

--- a/gh-pages/lib.js
+++ b/gh-pages/lib.js
@@ -413,3 +413,92 @@ export const makeLineDs = (xArr, yArr, i0, i1, color, label, gradient) => [
     fill: true,
   },
 ];
+
+// ── Daily status bars (GitHub-style uptime view) ─────────────
+// Returns array of { date, dayStart, dayEnd, metrics: { dl, ul, pi }, overall }
+// Each metric: { score, color, label, median, n } or null if no data
+// overall: composite score across all 3 metrics
+const DAY = 86_400_000;
+
+const statusLabel = (score) =>
+  score < 0.3 ? 'Excellent' : score < 0.6 ? 'Correct' : score < 0.8 ? 'Dégradé' : 'Critique';
+
+const statusColor = (score) => {
+  const hue = 120 * (1 - score);
+  const lightness = 50 + 10 * Math.sin((hue / 120) * Math.PI);
+  return `hsl(${hue.toFixed(0)}, 85%, ${lightness.toFixed(0)}%)`;
+};
+
+export const computeDailyStatus = (ts, dl, ul, pi, LEN, nDays = 30) => {
+  if (!LEN || !ts) return [];
+
+  // Find the end of the last day (midnight after last data point)
+  const lastTs = ts[LEN - 1];
+  const lastDate = new Date(lastTs);
+  const endDay = new Date(
+    lastDate.getFullYear(),
+    lastDate.getMonth(),
+    lastDate.getDate() + 1,
+  ).getTime();
+
+  const days = [];
+
+  for (let d = 0; d < nDays; d++) {
+    const dayEnd = endDay - d * DAY;
+    const dayStart = dayEnd - DAY;
+    const date = new Date(dayStart);
+    const dateStr = `${pad2(date.getDate())}/${pad2(date.getMonth() + 1)}/${date.getFullYear()}`;
+
+    const rng = filterRange(ts, LEN, dayStart, dayEnd - 1);
+
+    if (!rng) {
+      days.unshift({ date: dateStr, dayStart, dayEnd, metrics: null, overall: null });
+      continue;
+    }
+
+    const [i0, i1] = rng;
+    const n = i1 - i0;
+
+    const computeMetric = (metric, arr) => {
+      const sorted = sortedSlice(arr, i0, i1);
+      const med = medianOf(sorted);
+      let sum = 0;
+      for (let i = i0; i < i1; i++) sum += arr[i];
+      const avg = sum / n;
+      const q = qualityScore(metric, med, sorted, avg, n);
+      return {
+        score: q.score,
+        color: q.color,
+        label: statusLabel(q.score),
+        median: med,
+        n,
+        perf: q.perf,
+        stab: q.stab,
+        iqrRatio: q.iqrRatio,
+        q1: q.q1,
+        q3: q.q3,
+      };
+    };
+
+    const mDl = computeMetric('dl', dl);
+    const mUl = computeMetric('ul', ul);
+    const mPi = computeMetric('pi', pi);
+
+    // Overall = weighted average of the 3 scores
+    const overallScore = (mDl.score + mUl.score + mPi.score) / 3;
+
+    days.unshift({
+      date: dateStr,
+      dayStart,
+      dayEnd,
+      metrics: { dl: mDl, ul: mUl, pi: mPi },
+      overall: {
+        score: overallScore,
+        color: statusColor(overallScore),
+        label: statusLabel(overallScore),
+      },
+    });
+  }
+
+  return days;
+};

--- a/gh-pages/state.js
+++ b/gh-pages/state.js
@@ -10,8 +10,9 @@ export const data = { ts: null, dl: null, ul: null, pi: null, LEN: 0 };
 export const range = {
   start: 0,
   end: 0,
-  currentH: 48,
+  currentH: 24,
   isLive: true,
+  isToday: true,
   dataEnd: 0,
 };
 
@@ -32,5 +33,9 @@ export const initData = (ts, dl, ul, pi) => {
   data.LEN = ts.length;
   range.dataEnd = ts[ts.length - 1];
   range.end = range.dataEnd + 600_000;
-  range.start = range.end - range.currentH * HOUR;
+  // Default: "today" = midnight local time → now
+  const now = new Date();
+  const midnight = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  range.start = midnight;
+  range.currentH = (range.end - range.start) / HOUR;
 };

--- a/gh-pages/status-bar.js
+++ b/gh-pages/status-bar.js
@@ -1,0 +1,230 @@
+// ── Status bars (GitHub-style uptime view) ──────────────────
+// Self-contained: computes daily status from shared state, renders to #statusBars.
+// Tooltip on hover shows day details.
+
+import { computeDailyStatus } from './lib.js';
+import { data, range } from './state.js';
+
+const METRIC_LABELS = {
+  dl: { name: 'Download', unit: 'Mb/s', format: (v) => v.toFixed(0) + ' Mb/s' },
+  ul: { name: 'Upload', unit: 'Mb/s', format: (v) => v.toFixed(0) + ' Mb/s' },
+  pi: { name: 'Ping', unit: 'ms', format: (v) => v.toFixed(1) + ' ms' },
+};
+
+const ROWS = [
+  { key: 'dl', label: 'Download' },
+  { key: 'ul', label: 'Upload' },
+  { key: 'pi', label: 'Ping' },
+];
+
+/** Escape HTML */
+const esc = (s) =>
+  String(s).replace(
+    /[&<>"']/g,
+    (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c],
+  );
+
+/** Muted color for status bars (subdued by default, like GitHub) */
+const barColor = (score) => {
+  const hue = 120 * (1 - score);
+  return `hsl(${hue.toFixed(0)}, 40%, 28%)`;
+};
+
+/** Compute uptime percentage for a metric across all days with data */
+const uptimePct = (days, metricKey) => {
+  let good = 0,
+    total = 0;
+  for (const d of days) {
+    if (!d.metrics) continue;
+    total++;
+    if (d.metrics[metricKey].score < 0.6) good++;
+  }
+  return total > 0 ? ((good / total) * 100).toFixed(2) : '--';
+};
+
+/** Build one status bar row */
+const buildRow = (days, metricKey, label) => {
+  const pct = uptimePct(days, metricKey);
+  const nDays = days.length;
+
+  let barsHtml = '';
+  for (let i = 0; i < days.length; i++) {
+    const d = days[i];
+    const m = d.metrics?.[metricKey];
+    const color = m ? barColor(m.score) : 'var(--border)';
+    const tipDate = esc(d.date);
+    const tipLabel = m ? esc(m.label) : 'Aucune donnée';
+    const tipMedian = m ? esc(METRIC_LABELS[metricKey].format(m.median)) : '--';
+    const tipPts = m ? m.n + ' mesures' : '';
+
+    const tipPerf = m ? (100 * (1 - m.perf)).toFixed(0) : '';
+    const tipStab = m ? (100 * (1 - m.stab)).toFixed(0) : '';
+    const tipIqr = m ? (m.iqrRatio * 100).toFixed(1) : '';
+    const tipQ1 = m ? METRIC_LABELS[metricKey].format(m.q1) : '';
+    const tipQ3 = m ? METRIC_LABELS[metricKey].format(m.q3) : '';
+
+    barsHtml += `<div class="sb-bar" style="background:${color}" data-date="${tipDate}" data-label="${tipLabel}" data-median="${tipMedian}" data-pts="${tipPts}" data-score="${m ? m.score.toFixed(2) : ''}" data-perf="${tipPerf}" data-stab="${tipStab}" data-iqr="${tipIqr}" data-q1="${tipQ1}" data-q3="${tipQ3}" data-start="${d.dayStart}" data-end="${d.dayEnd}"></div>`;
+  }
+
+  const badgeClass =
+    pct === '--' ? 'none' : Number(pct) >= 99 ? 'ok' : Number(pct) >= 95 ? 'warn' : 'bad';
+  const badgeIcon = pct === '--' ? '' : Number(pct) >= 99 ? '✓' : '!';
+  const badgeLevel =
+    pct === '--'
+      ? ''
+      : Number(pct) >= 99
+        ? 'Excellent'
+        : Number(pct) >= 95
+          ? 'Correct'
+          : 'D\u00e9grad\u00e9';
+
+  return `<div class="sb-row" data-metric="${metricKey}">
+    <div class="sb-header">
+      <span class="sb-name">${esc(label)}</span>
+      <span class="sb-badge sb-badge-${badgeClass}" data-blabel="${esc(label)}" data-bpct="${pct}" data-blevel="${esc(badgeLevel)}">${badgeIcon}</span>
+    </div>
+    <div class="sb-bars">${barsHtml}</div>
+    <div class="sb-footer">
+      <span>${nDays} jours</span>
+      <span>${pct} % qualité</span>
+      <span>Auj.</span>
+    </div>
+  </div>`;
+};
+
+/** Tooltip element (shared, repositioned on hover) */
+let tipEl = null;
+
+const ensureTip = () => {
+  if (tipEl) return;
+  tipEl = document.createElement('div');
+  tipEl.className = 'sb-tip';
+  document.body.appendChild(tipEl);
+};
+
+const showTip = (bar) => {
+  ensureTip();
+  const date = bar.dataset.date;
+  const label = bar.dataset.label;
+  const median = bar.dataset.median;
+  const pts = bar.dataset.pts;
+
+  const perf = bar.dataset.perf;
+  const stab = bar.dataset.stab;
+  const iqr = bar.dataset.iqr;
+  const q1 = bar.dataset.q1;
+  const q3 = bar.dataset.q3;
+
+  let html = `<strong>${date}</strong><br><span class="sb-tip-label" style="color:${bar.style.background}">${label}</span>`;
+  if (median !== '--') {
+    html += `<div class="sb-tip-grid">`;
+    html += `<span class="sb-tip-k">Médiane</span><span class="sb-tip-v">${median}</span>`;
+    html += `<span class="sb-tip-k">Performance</span><span class="sb-tip-v">${perf}%</span>`;
+    html += `<span class="sb-tip-k">Stabilité</span><span class="sb-tip-v">${stab}%</span>`;
+    html += `<span class="sb-tip-k">IQR/méd</span><span class="sb-tip-v">${iqr}% <span class="sb-tip-dim">(${q1} → ${q3})</span></span>`;
+    html += `</div>`;
+  }
+  if (pts) html += `<span class="sb-tip-pts">${pts}</span>`;
+
+  tipEl.innerHTML = html;
+  tipEl.className = 'sb-tip sb-tip-above';
+  tipEl.style.display = 'block';
+
+  const r = bar.getBoundingClientRect();
+  tipEl.style.left = `${r.left + r.width / 2}px`;
+  tipEl.style.top = `${r.top - 6}px`;
+};
+
+const showBadgeTip = (badge) => {
+  ensureTip();
+  const label = badge.dataset.blabel;
+  const pct = badge.dataset.bpct;
+  const level = badge.dataset.blevel;
+
+  if (!level) return;
+
+  tipEl.innerHTML = `<strong>Qualit\u00e9 ${label}</strong><br><span class="sb-tip-label">${level}</span>
+<div class="sb-tip-grid">
+  <span class="sb-tip-k">Jours OK</span><span class="sb-tip-v">${pct}%</span>
+  <span class="sb-tip-k">Seuil \u2713</span><span class="sb-tip-v">\u2265 99%</span>
+  <span class="sb-tip-k">Pond\u00e9ration</span><span class="sb-tip-v">perf 30% + stab 70%</span>
+</div>
+<span class="sb-tip-pts">Un jour est \u00ab OK \u00bb si son score < 0.6</span>`;
+  tipEl.className = 'sb-tip sb-tip-below';
+  tipEl.style.display = 'block';
+
+  const r = badge.getBoundingClientRect();
+  tipEl.style.left = `${r.left + r.width / 2}px`;
+  tipEl.style.top = `${r.bottom + 6}px`;
+};
+
+const hideTip = () => {
+  if (tipEl) tipEl.style.display = 'none';
+};
+
+/** Initialize status bars. Call after data is loaded.
+ *  @param {function} [onBarClick] — called with (start, end) when a bar is clicked */
+export const initStatusBars = (onBarClick) => {
+  const container = document.getElementById('statusBars');
+  if (!container || !data.ts) return;
+
+  const days = computeDailyStatus(data.ts, data.dl, data.ul, data.pi, data.LEN, 30);
+
+  if (!days.length) {
+    container.style.display = 'none';
+    return;
+  }
+
+  container.innerHTML = ROWS.map((r) => buildRow(days, r.key, r.label)).join('');
+
+  // Event delegation for bar tooltip
+  container.addEventListener(
+    'mouseenter',
+    (e) => {
+      const bar = e.target.closest?.('.sb-bar');
+      if (bar) {
+        showTip(bar);
+        return;
+      }
+      const badge = e.target.closest?.('.sb-badge');
+      if (badge) showBadgeTip(badge);
+    },
+    true,
+  );
+
+  container.addEventListener(
+    'mouseleave',
+    (e) => {
+      const bar = e.target.closest?.('.sb-bar');
+      const badge = e.target.closest?.('.sb-badge');
+      if (bar || badge) hideTip();
+    },
+    true,
+  );
+
+  // Click on bar → navigate to that day's time range
+  container.addEventListener('click', (e) => {
+    const bar = e.target.closest?.('.sb-bar');
+    if (bar && bar.dataset.start && onBarClick) {
+      onBarClick(Number(bar.dataset.start), Number(bar.dataset.end));
+      hideTip();
+      return;
+    }
+    const badge = e.target.closest?.('.sb-badge');
+    if (badge) {
+      showBadgeTip(badge);
+      setTimeout(hideTip, 4000);
+    }
+  });
+};
+
+/** Highlight bars overlapping the current time range. Call after each render. */
+export const highlightActiveDay = () => {
+  const bars = document.querySelectorAll('.sb-bar');
+  for (const bar of bars) {
+    const s = Number(bar.dataset.start);
+    const e = Number(bar.dataset.end);
+    // Overlap: bar intersects [range.start, range.end]
+    bar.classList.toggle('sb-active', s < range.end && e > range.start);
+  }
+};

--- a/gh-pages/style.css
+++ b/gh-pages/style.css
@@ -807,6 +807,146 @@ nav .meta time {
   font-size: 0.9rem;
 }
 
+/* ── STATUS BARS (GitHub-style uptime) ── */
+.sb-section {
+  padding: 20px 0;
+  border-bottom: 1px solid var(--border);
+}
+.sb-section .stitle {
+  margin-bottom: 16px;
+}
+.sb-row {
+  margin-bottom: 16px;
+}
+.sb-row:last-child {
+  margin-bottom: 0;
+}
+.sb-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+.sb-name {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text);
+}
+.sb-badge {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+.sb-badge-ok {
+  background: rgba(34, 197, 94, 0.15);
+  color: var(--green);
+  border: 1px solid rgba(34, 197, 94, 0.3);
+}
+.sb-badge-warn {
+  background: rgba(234, 179, 8, 0.15);
+  color: var(--amber);
+  border: 1px solid rgba(234, 179, 8, 0.3);
+}
+.sb-badge-bad {
+  background: rgba(239, 68, 68, 0.15);
+  color: var(--red);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+}
+.sb-badge-none {
+  background: var(--surface);
+  color: var(--text3);
+  border: 1px solid var(--border);
+}
+.sb-bars {
+  display: flex;
+  gap: 1px;
+  height: 28px;
+  align-items: stretch;
+}
+.sb-bar {
+  flex: 1;
+  border-radius: 2px;
+  cursor: pointer;
+  transition:
+    filter 0.15s,
+    transform 0.1s;
+  min-width: 0;
+}
+.sb-bar:hover {
+  filter: brightness(1.8) saturate(1.6);
+  transform: scaleY(1.12);
+}
+.sb-active {
+  outline: 2px solid var(--text2);
+  outline-offset: -1px;
+}
+.sb-footer {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 4px;
+  font-size: 0.7rem;
+  color: var(--text3);
+  font-family: 'Geist Mono', 'Geist Mono Fallback', monospace;
+}
+.sb-tip {
+  display: none;
+  position: fixed;
+  background: var(--surface2);
+  color: var(--text);
+  font-size: 0.72rem;
+  font-family: 'Geist Mono', 'Geist Mono Fallback', monospace;
+  padding: 8px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border2);
+  pointer-events: none;
+  white-space: nowrap;
+  z-index: 120;
+  line-height: 1.5;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+}
+.sb-tip-above {
+  transform: translate(-50%, -100%);
+}
+.sb-tip-below {
+  transform: translateX(-50%);
+}
+.sb-tip-label {
+  font-weight: 700;
+  font-size: 0.78rem;
+}
+.sb-tip-grid {
+  display: grid;
+  grid-template-columns: auto auto;
+  gap: 1px 10px;
+  margin-top: 4px;
+}
+.sb-tip-k {
+  color: var(--text3);
+}
+.sb-tip-v {
+  text-align: right;
+  font-weight: 600;
+}
+.sb-tip-dim {
+  color: var(--text3);
+  font-weight: 400;
+  font-size: 0.65rem;
+}
+.sb-tip-pts {
+  display: block;
+  margin-top: 3px;
+  color: var(--text3);
+  font-size: 0.65rem;
+}
+.sb-badge {
+  cursor: help;
+}
+
 /* ── FOOTER ── */
 footer {
   border-top: 1px solid var(--border);

--- a/gh-pages/time-controls.js
+++ b/gh-pages/time-controls.js
@@ -5,10 +5,22 @@ import { HOUR, PRESETS } from './lib.js';
 import { range, data } from './state.js';
 import { render } from './charts.js';
 
+/** Set range to "today": midnight local → now */
+const setToday = () => {
+  const now = new Date();
+  range.start = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  range.end = range.dataEnd + 600_000;
+  range.currentH = (range.end - range.start) / HOUR;
+  range.isLive = true;
+  range.isToday = true;
+  render();
+};
+
 const setRange = (h) => {
   range.currentH = h;
   if (range.isLive) range.end = range.dataEnd + 600_000;
   range.start = range.end - range.currentH * HOUR;
+  range.isToday = false;
   render();
 };
 
@@ -17,13 +29,13 @@ const shift = (dir) => {
   range.start += s;
   range.end += s;
   range.isLive = range.end >= range.dataEnd;
+  range.isToday = false;
   render();
 };
 
-/** Reset to default 48h live view */
+/** Reset to default live "today" view */
 export const resetToLive = () => {
-  range.isLive = true;
-  setRange(48);
+  setToday();
 };
 
 /** Apply an arbitrary absolute range (used by time-picker). */
@@ -32,15 +44,20 @@ export const applyRange = (start, end) => {
   range.end = end;
   range.currentH = (range.end - range.start) / HOUR;
   range.isLive = range.end >= range.dataEnd;
+  range.isToday = false;
   render();
 };
 
 /** Bind all time control DOM elements. Call once at init. */
 export const initTimeControls = () => {
+  // Today button
+  document.getElementById('btnToday').addEventListener('click', setToday);
+
   // Preset buttons (e.g. 24h, 48h, 7d …)
-  document.querySelectorAll('.rb').forEach((b) =>
+  document.querySelectorAll('.rb:not(#btnToday)').forEach((b) =>
     b.addEventListener('click', () => {
       range.isLive = true;
+      range.isToday = false;
       setRange(parseInt(b.dataset.hours));
     }),
   );

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -12,7 +12,7 @@ export default defineConfig({
   use: {
     baseURL,
     headless: true,
-    actionTimeout: 10_000,
+    actionTimeout: isRemote ? 25_000 : 10_000,
     navigationTimeout: isRemote ? 30_000 : 15_000,
   },
   projects: [{ name: 'chromium', use: { browserName: 'chromium' } }],

--- a/scripts/build-gh-pages.sh
+++ b/scripts/build-gh-pages.sh
@@ -32,7 +32,7 @@ cp "$SCRIPT_DIR/gh-pages/style.css" "$BUILD_DIR/"
 cp -r "$SCRIPT_DIR/gh-pages/fonts" "$BUILD_DIR/"
 
 # JS modules — minify with terser when available, plain copy otherwise
-JS_MODULES=(app.js lib.js state.js sync-status.js alerts.js charts.js time-controls.js time-picker.js)
+JS_MODULES=(app.js lib.js state.js sync-status.js alerts.js charts.js time-controls.js time-picker.js status-bar.js)
 if command -v terser &>/dev/null; then
     for f in "${JS_MODULES[@]}"; do
         terser "$SCRIPT_DIR/gh-pages/$f" --compress --mangle --module -o "$BUILD_DIR/$f"

--- a/scripts/preview-dev.sh
+++ b/scripts/preview-dev.sh
@@ -34,4 +34,14 @@ echo ""
 echo "── Serving on http://localhost:${PORT} ──"
 echo "  Press Ctrl+C to stop"
 echo ""
-cd "$BUILD_DIR" && python3 -m http.server "$PORT"
+cd "$BUILD_DIR" && python3 -c "
+from http.server import SimpleHTTPRequestHandler
+from socketserver import ThreadingTCPServer
+
+class Handler(SimpleHTTPRequestHandler):
+    protocol_version = 'HTTP/1.1'
+
+ThreadingTCPServer.allow_reuse_address = True
+with ThreadingTCPServer(('', $PORT), Handler) as s:
+    s.serve_forever()
+"

--- a/scripts/publish-gh-pages.sh
+++ b/scripts/publish-gh-pages.sh
@@ -125,7 +125,17 @@ if [[ "$PREVIEW" == "true" ]]; then
     echo "  Press Ctrl+C to stop"
     echo ""
     cd "$BUILD_DIR"
-    python3 -m http.server 8080
+    python3 -c "
+from http.server import SimpleHTTPRequestHandler
+from socketserver import ThreadingTCPServer
+
+class Handler(SimpleHTTPRequestHandler):
+    protocol_version = 'HTTP/1.1'
+
+ThreadingTCPServer.allow_reuse_address = True
+with ThreadingTCPServer(('', 8080), Handler) as s:
+    s.serve_forever()
+"
 else
     echo ""
     echo "── Pushing to gh-pages branch ──"

--- a/scripts/publish-template.sh
+++ b/scripts/publish-template.sh
@@ -55,7 +55,17 @@ if [[ "$PREVIEW" == "true" ]]; then
     echo "  Press Ctrl+C to stop"
     echo ""
     cd "$BUILD_DIR"
-    python3 -m http.server 8080
+    python3 -c "
+from http.server import SimpleHTTPRequestHandler
+from socketserver import ThreadingTCPServer
+
+class Handler(SimpleHTTPRequestHandler):
+    protocol_version = 'HTTP/1.1'
+
+ThreadingTCPServer.allow_reuse_address = True
+with ThreadingTCPServer(('', 8080), Handler) as s:
+    s.serve_forever()
+"
 else
     echo ""
     echo "── Pushing to gh-pages branch ──"

--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -185,14 +185,14 @@ test.describe('interactive', () => {
     await expect(rangeLabel).not.toHaveText(initialText);
   });
 
-  // ── 10. Double-click on chart resets to default 48 h view ────
+  // ── 10. Double-click on chart resets to default "today" view ──
   test('double-click on chart resets to live view', async () => {
     // Ensure we're on 6h (may already be from previous test)
     await page.locator('.rb[data-hours="6"]').click();
     await expect(page.locator('.rb[data-hours="6"]')).toHaveClass(/on/);
 
     await page.locator('#bwChart').dblclick();
-    await expect(page.locator('.rb[data-hours="48"]')).toHaveClass(/on/);
+    await expect(page.locator('#btnToday')).toHaveClass(/on/);
   });
 
   // ── 11. Time range picker opens and has content ─────────────

--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -11,6 +11,7 @@ async function waitForAppReady(page) {
     () =>
       document.querySelector('#statsRow .stat .v')?.textContent?.trim() &&
       (Chart.getChart('bwChart')?.data?.datasets?.[0]?.data?.length ?? 0) > 0,
+    undefined,
     { timeout: 25_000 },
   );
 }

--- a/tests/lib.test.js
+++ b/tests/lib.test.js
@@ -3,6 +3,7 @@ import { strict as assert } from 'node:assert';
 import {
   lttb,
   bucketize,
+  computeDailyStatus,
   sortedSlice,
   medianOf,
   pctOf,
@@ -483,5 +484,99 @@ describe('makeLineDs', () => {
     assert.equal(ds[0].label, 'download');
     assert.equal(ds[0].fill, true);
     assert.equal(ds[0].backgroundColor, 'grad');
+  });
+});
+
+// ── computeDailyStatus ───────────────────────────────────────
+describe('computeDailyStatus', () => {
+  // Helper: generate data points every 10min for N days ending now
+  const generateData = (nDays, dlVal, ulVal, piVal) => {
+    const now = Date.now();
+    const endDay = new Date();
+    endDay.setHours(0, 0, 0, 0);
+    endDay.setDate(endDay.getDate() + 1);
+    const startMs = endDay.getTime() - nDays * 86_400_000;
+    const interval = 600_000; // 10 min
+    const count = Math.floor((nDays * 86_400_000) / interval);
+    const ts = new Float64Array(count);
+    const dl = new Float64Array(count);
+    const ul = new Float64Array(count);
+    const pi = new Float64Array(count);
+    for (let i = 0; i < count; i++) {
+      ts[i] = startMs + i * interval;
+      dl[i] = dlVal;
+      ul[i] = ulVal;
+      pi[i] = piVal;
+    }
+    return { ts, dl, ul, pi, LEN: count };
+  };
+
+  it('returns empty array for zero-length data', () => {
+    const result = computeDailyStatus(null, null, null, null, 0, 30);
+    assert.deepEqual(result, []);
+  });
+
+  it('returns nDays entries', () => {
+    const d = generateData(30, 900, 600, 10);
+    const result = computeDailyStatus(d.ts, d.dl, d.ul, d.pi, d.LEN, 30);
+    assert.equal(result.length, 30);
+  });
+
+  it('all days have metrics for continuous data', () => {
+    const d = generateData(5, 900, 600, 10);
+    const result = computeDailyStatus(d.ts, d.dl, d.ul, d.pi, d.LEN, 5);
+    for (const day of result) {
+      assert.notEqual(day.metrics, null, `Day ${day.date} should have metrics`);
+      assert.ok(day.metrics.dl);
+      assert.ok(day.metrics.ul);
+      assert.ok(day.metrics.pi);
+    }
+  });
+
+  it('days beyond data range have null metrics', () => {
+    const d = generateData(3, 900, 600, 10);
+    const result = computeDailyStatus(d.ts, d.dl, d.ul, d.pi, d.LEN, 10);
+    assert.equal(result.length, 10);
+    // First 7 days (oldest) should have null metrics
+    const noData = result.filter((r) => r.metrics === null);
+    assert.ok(noData.length >= 6, `Expected >= 6 days without data, got ${noData.length}`);
+  });
+
+  it('excellent data yields low scores', () => {
+    const d = generateData(5, 900, 600, 10);
+    const result = computeDailyStatus(d.ts, d.dl, d.ul, d.pi, d.LEN, 5);
+    for (const day of result) {
+      if (!day.metrics) continue;
+      assert.ok(day.metrics.dl.score < 0.3, `DL score ${day.metrics.dl.score} should be < 0.3`);
+      assert.ok(day.metrics.ul.score < 0.3, `UL score ${day.metrics.ul.score} should be < 0.3`);
+      assert.ok(day.metrics.pi.score < 0.3, `PI score ${day.metrics.pi.score} should be < 0.3`);
+      assert.ok(day.overall.score < 0.3, `Overall score ${day.overall.score} should be < 0.3`);
+    }
+  });
+
+  it('each day has a date string in dd/MM/yyyy format', () => {
+    const d = generateData(5, 900, 600, 10);
+    const result = computeDailyStatus(d.ts, d.dl, d.ul, d.pi, d.LEN, 5);
+    for (const day of result) {
+      assert.match(day.date, /^\d{2}\/\d{2}\/\d{4}$/);
+    }
+  });
+
+  it('days are ordered chronologically (oldest first)', () => {
+    const d = generateData(5, 900, 600, 10);
+    const result = computeDailyStatus(d.ts, d.dl, d.ul, d.pi, d.LEN, 5);
+    for (let i = 1; i < result.length; i++) {
+      assert.ok(result[i].dayStart > result[i - 1].dayStart);
+    }
+  });
+
+  it('overall score has color and label', () => {
+    const d = generateData(3, 900, 600, 10);
+    const result = computeDailyStatus(d.ts, d.dl, d.ul, d.pi, d.LEN, 3);
+    for (const day of result) {
+      if (!day.overall) continue;
+      assert.ok(day.overall.color.startsWith('hsl('));
+      assert.ok(['Excellent', 'Correct', 'Dégradé', 'Critique'].includes(day.overall.label));
+    }
   });
 });


### PR DESCRIPTION
## Summary
<img width="979" height="827" alt="image" src="https://github.com/user-attachments/assets/22f26871-c672-4ec7-9ed1-ed07bed75885" />

Add GitHub-style 30-day status bars to the monitoring dashboard.

### Features
- **Status bars**: 30 colored bars (one per day) showing quality score based on `0.3×perf + 0.7×stab`
- **Today button**: New default view replacing 48h — shows midnight-to-now range
- **Click-to-navigate**: Click any bar to jump to that day's time range
- **Active day indicator**: Outline highlights the bar matching the current view
- **Hover tooltips**: Grid-based tooltips showing per-metric breakdown (DL/UL/Ping scores, medians, IQR)
- **Badge tooltips**: Hover on quality badges for section-level summary

### Browser compatibility fix
- Upgrade dev/preview servers to threaded HTTP/1.1 (`ThreadingTCPServer` + `protocol_version = 'HTTP/1.1'`)
- Removes modulepreload saturation issue in Brave/Chrome (6-conn limit)

### Tests
- 75 unit tests (8 new for `computeDailyStatus`)
- 12 E2E tests (updated double-click assertion for Today button)

### Files changed
| Commit | Scope | Files |
|--------|-------|-------|
| `feat:` | Frontend code | app.js, lib.js, status-bar.js, state.js, charts.js, time-controls.js, style.css, index.template.html, build-gh-pages.sh |
| `fix:` | Dev servers | preview-dev.sh, publish-gh-pages.sh, publish-template.sh |
| `test:` | Test suite | lib.test.js, e2e.spec.js |
| `docs:` | Documentation | README.md, UBIQUITOUS_LANGUAGE.md |