### PR TITLE
fix: relax status bar badge thresholds for residential monitoring

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,5 +30,18 @@ jobs:
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
 
-      - name: Run unit tests
-        run: node --test tests/lib.test.js
+      - name: Run unit tests with coverage
+        run: |
+          mkdir -p coverage
+          node --test --experimental-test-coverage \
+            --test-reporter lcov --test-reporter-destination coverage/lcov.info \
+            --test-reporter spec --test-reporter-destination stdout \
+            tests/lib.test.js tests/status-bar.test.js
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: coverage/lcov.info
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ node_modules/
 test-results/
 playwright-report/
 
+# Coverage
+coverage/
+
 # Lighthouse
 lighthouse-reports/
 

--- a/Justfile
+++ b/Justfile
@@ -147,9 +147,17 @@ clean-all: clean
 test:
     bash test-stack.sh
 
-# Run lib.js unit tests (Node.js, no browser needed)
+# Run unit tests (Node.js, no browser needed)
 test-unit:
-    node --test tests/lib.test.js
+    node --test tests/lib.test.js tests/status-bar.test.js
+
+# Run unit tests with V8 coverage report
+test-coverage:
+    mkdir -p coverage
+    node --test --experimental-test-coverage \
+        --test-reporter lcov --test-reporter-destination coverage/lcov.info \
+        --test-reporter spec --test-reporter-destination stdout \
+        tests/lib.test.js tests/status-bar.test.js
 
 # Run Playwright E2E tests against a running preview
 test-e2e:

--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ just install-timers
 | Commande                     | RPi requis | Description                                                           |
 | ---------------------------- | ---------- | --------------------------------------------------------------------- |
 | `just test`                  | **oui**    | Suite de régression complète (17 checks)                              |
-| `just test-unit`             | non        | Tests unitaires `lib.js` (Node.js, 75 tests, ~500ms)                  |
+| `just test-unit`             | non        | Tests unitaires lib.js + status-bar.js (Node.js, 94 tests, ~1s)       |
+| `just test-coverage`         | non        | Tests unitaires + rapport couverture V8 (lcov dans `coverage/`)       |
 | `just test-e2e`              | non        | Tests E2E Playwright (12 tests, nécessite un preview actif sur :8080) |
 | `just check`                 | **oui**    | Health check rapide des 4 services                                    |
 | `just e2e [url]`             | non        | Tests E2E Playwright contre une preview (défaut: :8080)               |

--- a/gh-pages/status-bar.js
+++ b/gh-pages/status-bar.js
@@ -25,13 +25,13 @@ const esc = (s) =>
   );
 
 /** Muted color for status bars (subdued by default, like GitHub) */
-const barColor = (score) => {
+export const barColor = (score) => {
   const hue = 120 * (1 - score);
   return `hsl(${hue.toFixed(0)}, 40%, 28%)`;
 };
 
 /** Compute uptime percentage for a metric across all days with data */
-const uptimePct = (days, metricKey) => {
+export const uptimePct = (days, metricKey) => {
   let good = 0,
     total = 0;
   for (const d of days) {
@@ -40,6 +40,17 @@ const uptimePct = (days, metricKey) => {
     if (d.metrics[metricKey].score < 0.6) good++;
   }
   return total > 0 ? ((good / total) * 100).toFixed(2) : '--';
+};
+
+/** Compute badge class, icon and level from uptime percentage string */
+export const badgeInfo = (pct) => {
+  if (pct === '--') return { cls: 'none', icon: '', level: '' };
+  const p = Number(pct);
+  return {
+    cls: p >= 90 ? 'ok' : p >= 70 ? 'warn' : 'bad',
+    icon: p >= 90 ? '✓' : '!',
+    level: p >= 90 ? 'Excellent' : p >= 70 ? 'Correct' : 'Dégradé',
+  };
 };
 
 /** Build one status bar row */
@@ -67,15 +78,12 @@ const buildRow = (days, metricKey, label) => {
   }
 
   const p = Number(pct);
-  const badgeClass = pct === '--' ? 'none' : p >= 90 ? 'ok' : p >= 70 ? 'warn' : 'bad';
-  const badgeIcon = pct === '--' ? '' : p >= 90 ? '✓' : '!';
-  const badgeLevel =
-    pct === '--' ? '' : p >= 90 ? 'Excellent' : p >= 70 ? 'Correct' : 'D\u00e9grad\u00e9';
+  const badge = badgeInfo(pct);
 
   return `<div class="sb-row" data-metric="${metricKey}">
     <div class="sb-header">
       <span class="sb-name">${esc(label)}</span>
-      <span class="sb-badge sb-badge-${badgeClass}" data-blabel="${esc(label)}" data-bpct="${pct}" data-blevel="${esc(badgeLevel)}">${badgeIcon}</span>
+      <span class="sb-badge sb-badge-${badge.cls}" data-blabel="${esc(label)}" data-bpct="${pct}" data-blevel="${esc(badge.level)}">${badge.icon}</span>
     </div>
     <div class="sb-bars">${barsHtml}</div>
     <div class="sb-footer">

--- a/gh-pages/status-bar.js
+++ b/gh-pages/status-bar.js
@@ -66,17 +66,11 @@ const buildRow = (days, metricKey, label) => {
     barsHtml += `<div class="sb-bar" style="background:${color}" data-date="${tipDate}" data-label="${tipLabel}" data-median="${tipMedian}" data-pts="${tipPts}" data-score="${m ? m.score.toFixed(2) : ''}" data-perf="${tipPerf}" data-stab="${tipStab}" data-iqr="${tipIqr}" data-q1="${tipQ1}" data-q3="${tipQ3}" data-start="${d.dayStart}" data-end="${d.dayEnd}"></div>`;
   }
 
-  const badgeClass =
-    pct === '--' ? 'none' : Number(pct) >= 99 ? 'ok' : Number(pct) >= 95 ? 'warn' : 'bad';
-  const badgeIcon = pct === '--' ? '' : Number(pct) >= 99 ? '✓' : '!';
+  const p = Number(pct);
+  const badgeClass = pct === '--' ? 'none' : p >= 90 ? 'ok' : p >= 70 ? 'warn' : 'bad';
+  const badgeIcon = pct === '--' ? '' : p >= 90 ? '✓' : '!';
   const badgeLevel =
-    pct === '--'
-      ? ''
-      : Number(pct) >= 99
-        ? 'Excellent'
-        : Number(pct) >= 95
-          ? 'Correct'
-          : 'D\u00e9grad\u00e9';
+    pct === '--' ? '' : p >= 90 ? 'Excellent' : p >= 70 ? 'Correct' : 'D\u00e9grad\u00e9';
 
   return `<div class="sb-row" data-metric="${metricKey}">
     <div class="sb-header">
@@ -146,7 +140,7 @@ const showBadgeTip = (badge) => {
   tipEl.innerHTML = `<strong>Qualit\u00e9 ${label}</strong><br><span class="sb-tip-label">${level}</span>
 <div class="sb-tip-grid">
   <span class="sb-tip-k">Jours OK</span><span class="sb-tip-v">${pct}%</span>
-  <span class="sb-tip-k">Seuil \u2713</span><span class="sb-tip-v">\u2265 99%</span>
+  <span class="sb-tip-k">Seuil \u2713</span><span class="sb-tip-v">\u2265 90%</span>
   <span class="sb-tip-k">Pond\u00e9ration</span><span class="sb-tip-v">perf 30% + stab 70%</span>
 </div>
 <span class="sb-tip-pts">Un jour est \u00ab OK \u00bb si son score < 0.6</span>`;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
     "private": true,
     "type": "module",
     "scripts": {
-        "test:unit": "node --test tests/lib.test.js",
+        "test:unit": "node --test tests/lib.test.js tests/status-bar.test.js",
+        "test:coverage": "mkdir -p coverage && node --test --experimental-test-coverage --test-reporter lcov --test-reporter-destination coverage/lcov.info --test-reporter spec --test-reporter-destination stdout tests/lib.test.js tests/status-bar.test.js",
         "test:e2e": "playwright test"
     },
     "devDependencies": {

--- a/tests/status-bar.test.js
+++ b/tests/status-bar.test.js
@@ -1,0 +1,111 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { barColor, uptimePct, badgeInfo } from '../gh-pages/status-bar.js';
+
+// ── barColor ─────────────────────────────────────────────────
+describe('barColor', () => {
+  it('returns green hue for score 0 (perfect)', () => {
+    assert.equal(barColor(0), 'hsl(120, 40%, 28%)');
+  });
+  it('returns red hue for score 1 (critical)', () => {
+    assert.equal(barColor(1), 'hsl(0, 40%, 28%)');
+  });
+  it('returns intermediate hue for score 0.5', () => {
+    assert.equal(barColor(0.5), 'hsl(60, 40%, 28%)');
+  });
+});
+
+// ── uptimePct ────────────────────────────────────────────────
+describe('uptimePct', () => {
+  const mkDay = (score) => ({ metrics: { dl: { score } } });
+
+  it('returns -- for empty array', () => {
+    assert.equal(uptimePct([], 'dl'), '--');
+  });
+  it('returns -- when all days have no metrics', () => {
+    assert.equal(uptimePct([{ metrics: null }, { metrics: null }], 'dl'), '--');
+  });
+  it('returns 100.00 when all days are good (score < 0.6)', () => {
+    const days = [mkDay(0.1), mkDay(0.2), mkDay(0.5)];
+    assert.equal(uptimePct(days, 'dl'), '100.00');
+  });
+  it('returns 0.00 when all days are bad (score >= 0.6)', () => {
+    const days = [mkDay(0.6), mkDay(0.8), mkDay(1.0)];
+    assert.equal(uptimePct(days, 'dl'), '0.00');
+  });
+  it('computes correct percentage for mixed days', () => {
+    // 7 bad + 23 good = 23/30 ≈ 76.67%
+    const days = Array.from({ length: 7 }, () => mkDay(0.8)).concat(
+      Array.from({ length: 23 }, () => mkDay(0.2)),
+    );
+    assert.equal(uptimePct(days, 'dl'), '76.67');
+  });
+  it('skips days without metrics', () => {
+    const days = [mkDay(0.1), { metrics: null }, mkDay(0.1)];
+    assert.equal(uptimePct(days, 'dl'), '100.00');
+  });
+});
+
+// ── badgeInfo ────────────────────────────────────────────────
+describe('badgeInfo', () => {
+  it('returns none/empty for "--" (no data)', () => {
+    const b = badgeInfo('--');
+    assert.equal(b.cls, 'none');
+    assert.equal(b.icon, '');
+    assert.equal(b.level, '');
+  });
+
+  // Excellent: >= 90%
+  it('returns ok/Excellent for 100%', () => {
+    const b = badgeInfo('100.00');
+    assert.equal(b.cls, 'ok');
+    assert.equal(b.icon, '✓');
+    assert.equal(b.level, 'Excellent');
+  });
+  it('returns ok/Excellent for 90% (boundary)', () => {
+    const b = badgeInfo('90.00');
+    assert.equal(b.cls, 'ok');
+    assert.equal(b.level, 'Excellent');
+  });
+  it('returns ok/Excellent for 96.67% (Ping-like)', () => {
+    const b = badgeInfo('96.67');
+    assert.equal(b.cls, 'ok');
+    assert.equal(b.level, 'Excellent');
+  });
+
+  // Correct: >= 70% and < 90%
+  it('returns warn/Correct for 89.99% (just below Excellent)', () => {
+    const b = badgeInfo('89.99');
+    assert.equal(b.cls, 'warn');
+    assert.equal(b.icon, '!');
+    assert.equal(b.level, 'Correct');
+  });
+  it('returns warn/Correct for 73.33% (Download-like)', () => {
+    const b = badgeInfo('73.33');
+    assert.equal(b.cls, 'warn');
+    assert.equal(b.level, 'Correct');
+  });
+  it('returns warn/Correct for 70% (boundary)', () => {
+    const b = badgeInfo('70.00');
+    assert.equal(b.cls, 'warn');
+    assert.equal(b.level, 'Correct');
+  });
+
+  // Dégradé: < 70%
+  it('returns bad/Dégradé for 69.99% (just below Correct)', () => {
+    const b = badgeInfo('69.99');
+    assert.equal(b.cls, 'bad');
+    assert.equal(b.icon, '!');
+    assert.equal(b.level, 'Dégradé');
+  });
+  it('returns bad/Dégradé for 43.33% (Upload-like)', () => {
+    const b = badgeInfo('43.33');
+    assert.equal(b.cls, 'bad');
+    assert.equal(b.level, 'Dégradé');
+  });
+  it('returns bad/Dégradé for 0%', () => {
+    const b = badgeInfo('0.00');
+    assert.equal(b.cls, 'bad');
+    assert.equal(b.level, 'Dégradé');
+  });
+});


### PR DESCRIPTION
## Problem

Badge thresholds (99%/95%) were modeled on GitHub SLA uptime — far too strict for residential internet monitoring.

| Metric | Quality % | Old badge | New badge |
|--------|-----------|-----------|-----------|
| Download | 73.33% | 🔴 Dégradé | 🟡 Correct |
| Upload | 43.33% | 🔴 Dégradé | 🔴 Dégradé |
| Ping | 96.67% | 🟡 Correct | ✅ Excellent |

## Fix

| Level | Old threshold | New threshold |
|-------|---------------|---------------|
| ✓ Excellent | ≥ 99% | ≥ 90% |
| ! Correct | ≥ 95% | ≥ 70% |
| ! Dégradé | < 95% | < 70% |

Badge tooltip also updated to show ≥ 90% threshold.